### PR TITLE
Release: Merge develop to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,14 +81,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
+      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -211,13 +211,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"


### PR DESCRIPTION
## Summary
- Merged 10 Dependabot dependency updates:
  - @babel/generator 7.28.6 → 7.29.0
  - @babel/compat-data 7.28.6 → 7.29.0
  - @babel/code-frame 7.28.6 → 7.29.0
  - @types/node 25.0.10 → 25.2.0
  - @babel/plugin-syntax-typescript 7.27.1 → 7.28.6
  - @babel/types 7.28.6 → 7.29.0
  - @babel/plugin-syntax-jsx 7.27.1 → 7.28.6
  - @babel/plugin-syntax-import-attributes 7.27.1 → 7.28.6
  - patch-updates group (2 updates)
  - Additional patch-updates group from PR #32

## Test plan
- [ ] All CI checks pass
- [ ] Extension loads correctly in Chrome
- [ ] No regressions in accessibility checking functionality