### PR TITLE
chore: configure npm auth for the afixt scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 jobs:
   lint:
     name: Lint Code
@@ -264,6 +267,3 @@ jobs:
             console.log('✓ Extension name:', manifest.name);
             console.log('✓ Manifest version:', manifest.manifest_version);
           "
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,3 +264,6 @@ jobs:
             console.log('✓ Extension name:', manifest.name);
             console.log('✓ Manifest version:', manifest.manifest_version);
           "
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
@@ -86,6 +89,3 @@ jobs:
         if: steps.detect.outputs.type == 'node'
         run: npm test --if-present
         continue-on-error: true
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -86,3 +86,6 @@ jobs:
         if: steps.detect.outputs.type == 'node'
         run: npm test --if-present
         continue-on-error: true
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 jobs:
   validate:
     name: Validate Release
@@ -242,6 +245,3 @@ jobs:
           echo "❌ Failed to release Accessibility Highlighter ${{ needs.validate.outputs.version }}"
           echo "Check the workflow logs for details."
           exit 1
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,3 +242,6 @@ jobs:
           echo "❌ Failed to release Accessibility Highlighter ${{ needs.validate.outputs.version }}"
           echo "Check the workflow logs for details."
           exit 1
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 jobs:
   # Quick scan on every push/PR
   npm-audit:
@@ -119,6 +122,3 @@ jobs:
           name: license-report
           path: licenses.json
           retention-days: 90
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -119,3 +119,6 @@ jobs:
           name: license-report
           path: licenses.json
           retention-days: 90
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.npmrc
+++ b/.npmrc
@@ -8,6 +8,7 @@ prefer-offline=true
 cache-min=3600
 
 # CI optimizations
-loglevel=error@afixt:registry=https://registry.npmjs.org/
+loglevel=error
+@afixt:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -8,4 +8,6 @@ prefer-offline=true
 cache-min=3600
 
 # CI optimizations
-loglevel=error
+loglevel=error@afixt:registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+always-auth=true


### PR DESCRIPTION
## Summary
- Wire NPM_TOKEN for @afixt scoped private packages so CI can resolve them.
- .npmrc + workflow-level NPM_TOKEN env.

## Test plan
- [ ] CI green (install resolves @afixt/* deps)
- [ ] Local: NPM_TOKEN env var set, install works without WARN