### PR TITLE
chore(tooling): adopt phase 2 of issue #56 quality stack

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Docs
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '**/*.md'
+      - .github/workflows/docs.yml
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC — catches external link rot
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: Lychee link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --exclude-path node_modules
+            --exclude-path coverage
+            --exclude-path reports
+            --exclude-path dist
+            --exclude-path scratchpads
+            './**/*.md'
+          fail: false
+
+      - name: Create issue on broken links (scheduled runs only)
+        if: github.event_name == 'schedule' && env.lychee_exit_code != '0'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: 'Link checker: broken links detected'
+          content-filepath: ./lychee/out.md
+          labels: |
+            documentation
+            broken-links

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  schedule:
+    - cron: '0 6 * * 1' # Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -25,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies
@@ -45,6 +47,42 @@ jobs:
           path: npm-audit-results.json
           retention-days: 30
 
+  # Secret scanning (every push/PR) — installs gitleaks binary directly to
+  # avoid the gitleaks-action org-licensing dependency.
+  gitleaks:
+    name: Gitleaks (secrets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --no-banner --redact --verbose
+        continue-on-error: true
+
+  # OSV-Scanner — Google vulnerability scanner (every push/PR)
+  osv-scanner:
+    name: OSV-Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2.1.0
+        with:
+          scan-args: |-
+            --lockfile=package-lock.json
+            --recursive
+            .
+        continue-on-error: true
+
   # OWASP Dependency Check (comprehensive - weekly only)
   owasp-dependency-check:
     name: OWASP Dependency Check
@@ -56,7 +94,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies
@@ -97,7 +135,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies

--- a/docs/adr/0002-tooling-phase-2.md
+++ b/docs/adr/0002-tooling-phase-2.md
@@ -1,0 +1,109 @@
+# ADR 0002: Tooling stack — Phase 2 (issue #56)
+
+- **Status**: Accepted
+- **Date**: 2026-05-11
+- **Deciders**: @karlgroves
+
+## Context
+
+[ADR 0001](./0001-tooling-phase-1.md) adopted the foundations of issue #56's
+tooling stack and listed four explicit Phase-2 follow-ups:
+
+1. Resolve remaining ESLint warnings.
+2. Wire `lychee` + `gitleaks` into CI (currently local-only).
+3. Decide on Semgrep / OSV-Scanner pre-push gates.
+4. Enable the OWASP Dependency-Check scheduled job.
+5. Refactor `contentScript.js` (3000+ lines) to satisfy tightened sonarjs
+   rules.
+
+## Decision
+
+### Adopted in Phase 2
+
+| Area              | Tool                                | Notes                                                                                                                                            |
+| ----------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Secret scanning   | gitleaks job in `security.yml`      | Installs the binary directly to avoid org-licensing dependency on `gitleaks-action`                                                              |
+| Vuln scanning     | OSV-Scanner job in `security.yml`   | Runs on every push/PR; non-blocking                                                                                                              |
+| Schedule          | `cron: '0 6 * * 1'` on security.yml | Re-enables the previously-gated OWASP Dependency-Check and license-check jobs (their `if: schedule` condition could never fire without a `cron`) |
+| Link rot          | New `docs.yml` workflow             | Runs `lychee` on PR (when `.md` changes) and on a weekly schedule                                                                                |
+| ESLint tightening | `warn` → `error`                    | sonarjs/prefer-immediate-return, sonarjs/prefer-single-boolean-return, unicorn/explicit-length-check, promise/catch-or-return                    |
+| ESLint tightening | `warn` → `error`                    | security/detect-non-literal-regexp, security/detect-unsafe-regex                                                                                 |
+| ESLint tightening | `warn` → `error`                    | jsdoc/check-tag-names, jsdoc/check-param-names, jsdoc/check-types                                                                                |
+| ESLint tightening | `off` → `error`                     | sonarjs/no-collapsible-if (fixed 2 test sites)                                                                                                   |
+
+### Deferred — contentScript.js modularization (Phase 2b)
+
+Refactoring `contentScript.js` into smaller modules is blocked on a
+discovered architectural duplication that must be reconciled first:
+
+- `src/contentScript.js` is 3399 lines. This is what Jest loads via
+  `require('../src/contentScript.js')`.
+- `extension-package/contentScript.js` is 3195 lines. This is what
+  `scripts/build.js` copies into the per-browser distribution.
+- The two files differ by ~678 lines of diff.
+- `src/modules/{config,overlayManager,state}.js` exist but the runtime
+  extension does not load them — only Jest tests import them.
+- `npm run build` (defined in `package.json`) copies from `src/` to
+  `dist/`. `npm run build:all` (`scripts/build.js`) copies from
+  `extension-package/`. The two build paths target different source trees.
+
+Splitting `contentScript.js` while two diverged source-of-truth copies
+exist would either widen the drift or silently drop changes that live in
+only one copy. The contentScript.js modularization therefore depends on:
+
+1. **An ADR** picking one canonical source tree (`src/` vs
+   `extension-package/`) and explicitly designating the other as
+   generated or deleting it.
+2. **A reconciliation pass** merging the diverged contents and removing
+   the redundant copy.
+3. **Optionally a build-time concatenation or Manifest V3 multi-content-
+   script setup** so the existing `src/modules/` files can be loaded at
+   runtime instead of duplicated in `contentScript.js`.
+
+After those prerequisites land, the tightened ESLint rules in this Phase
+(`max-lines`, `max-lines-per-function`, `complexity`, `max-depth`,
+`max-nested-callbacks`, `max-params`) can be added on top of a
+modularized content script without forcing per-file overrides.
+
+### Still deferred from Phase 1
+
+- `promise/no-nesting` — `background.js:131,166,170` use legacy
+  `chrome.*` callback-style nested promises. Refactor to async/await
+  tracked separately.
+- Semgrep pre-push gate — covered transitively by CodeQL + the new
+  OSV-Scanner CI job. Reconsider only if those prove insufficient.
+
+## Consequences
+
+### Easier
+
+- Every push/PR now runs the full security triplet locally and in CI:
+  npm-audit + gitleaks + OSV-Scanner.
+- OWASP Dependency-Check and license compliance actually run weekly,
+  catching CVEs that surface after the last code change.
+- Link rot in docs is now caught on a weekly cadence and surfaces broken
+  links on doc-changing PRs.
+- ESLint signal is stricter without any code changes required —
+  promoted rules already pass clean.
+
+### Harder / follow-up
+
+- Phase 2b (contentScript.js modularization) is the largest remaining
+  acceptance-criteria item from issue #56 and now requires its own
+  preparatory ADR before work can begin.
+- `gitleaks` in CI installs a pinned binary version; that pin should be
+  reviewed when gitleaks publishes major releases.
+
+## Alternatives considered
+
+- **Push the contentScript.js refactor through despite the drift**:
+  rejected. Would widen src/ vs extension-package/ divergence or
+  accidentally lose code present in only one copy.
+- **Use `gitleaks-action` instead of installing the binary**: rejected
+  because gitleaks-action requires a license key for organizations on
+  private repos. Installing the binary directly is portable and
+  license-free.
+- **Add Semgrep pre-push gate**: rejected for Phase 2 — CodeQL
+  (scheduled) plus OSV-Scanner (per push) already cover the primary
+  attack surface, and adding Semgrep to pre-push would slow local
+  iteration without a corresponding signal gain.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,20 +94,18 @@ const projectRules = {
 const pluginRules = {
   // sonarjs — code smells, dead code, redundancy
   'sonarjs/no-identical-functions': 'error',
-  // A handful of existing nested ifs are intentionally structured for clarity.
-  'sonarjs/no-collapsible-if': 'off',
+  'sonarjs/no-collapsible-if': 'error',
   'sonarjs/no-redundant-boolean': 'error',
   'sonarjs/no-redundant-jump': 'error',
   'sonarjs/no-unused-collection': 'error',
   'sonarjs/no-useless-catch': 'error',
-  'sonarjs/prefer-immediate-return': 'warn',
-  'sonarjs/prefer-single-boolean-return': 'warn',
+  'sonarjs/prefer-immediate-return': 'error',
+  'sonarjs/prefer-single-boolean-return': 'error',
 
   // security — common Node/browser pitfalls
   'security/detect-eval-with-expression': 'error',
-  'security/detect-non-literal-regexp': 'warn',
-  // Heuristic overreports on standard `\d+(\.\d+)?` patterns; surface as warning.
-  'security/detect-unsafe-regex': 'warn',
+  'security/detect-non-literal-regexp': 'error',
+  'security/detect-unsafe-regex': 'error',
   'security/detect-buffer-noassert': 'error',
   'security/detect-child-process': 'error',
   'security/detect-pseudoRandomBytes': 'error',
@@ -120,15 +118,16 @@ const pluginRules = {
   'unicorn/no-array-for-each': 'off',
   'unicorn/prefer-top-level-await': 'off',
   'unicorn/prefer-module': 'off',
-  'unicorn/explicit-length-check': 'warn',
+  'unicorn/explicit-length-check': 'error',
   'unicorn/no-array-reduce': 'off',
 
   // promise — async correctness
   'promise/no-return-wrap': 'error',
   'promise/param-names': 'error',
-  'promise/catch-or-return': 'warn',
-  // The legacy chrome.* API style nests .then/.catch under outer .then chains;
-  // refactoring to async/await is tracked as separate work.
+  'promise/catch-or-return': 'error',
+  // The legacy chrome.* callback API style in background.js nests promises
+  // under outer .then chains; refactoring to async/await is tracked
+  // separately. See background.js lines 131, 166, 170.
   'promise/no-nesting': 'off',
 
   // n — Node-specific rules (light touch; most of this project is browser)
@@ -148,9 +147,9 @@ const pluginRules = {
 
   // jsdoc — keep documentation accurate where it exists; do not force it on
   // every export yet (project has many undocumented internals).
-  'jsdoc/check-tag-names': ['warn', { definedTags: ['fileoverview'] }],
-  'jsdoc/check-param-names': 'warn',
-  'jsdoc/check-types': 'warn',
+  'jsdoc/check-tag-names': ['error', { definedTags: ['fileoverview'] }],
+  'jsdoc/check-param-names': 'error',
+  'jsdoc/check-types': 'error',
   'jsdoc/no-undefined-types': 'off',
   'jsdoc/require-jsdoc': 'off'
 };

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -357,10 +357,9 @@ test.describe('Accessibility Highlighter Extension E2E Tests', () => {
 
         // Check form fields without labels
         document.querySelectorAll('input[type="text"], input[type="email"]').forEach(input => {
-          if (!input.id || !document.querySelector(`label[for="${input.id}"]`)) {
-            if (!input.getAttribute('aria-label')) {
-              _issues.push({ element: input, message: 'Form field without label' });
-            }
+          const _hasLabel = input.id && document.querySelector(`label[for="${input.id}"]`);
+          if (!_hasLabel && !input.getAttribute('aria-label')) {
+            _issues.push({ element: input, message: 'Form field without label' });
           }
         });
 

--- a/tests/real-dom-scenarios.test.js
+++ b/tests/real-dom-scenarios.test.js
@@ -328,14 +328,12 @@ describe('Real DOM Scenarios Tests', () => {
         if (_tbody) {
           _tbody.children.forEach((row, rowIndex) => {
             const _firstCell = row.children[0];
-            if (_firstCell && _firstCell.tagName === 'TH') {
-              if (!_firstCell.getAttribute('scope')) {
-                _issues.push({
-                  issue: 'missing_row_scope',
-                  message: `Row header at row ${rowIndex + 1} missing scope attribute`,
-                  element: _firstCell
-                });
-              }
+            if (_firstCell && _firstCell.tagName === 'TH' && !_firstCell.getAttribute('scope')) {
+              _issues.push({
+                issue: 'missing_row_scope',
+                message: `Row header at row ${rowIndex + 1} missing scope attribute`,
+                element: _firstCell
+              });
             }
           });
         }


### PR DESCRIPTION
## Summary

Phase 2 of issue #56 — closes the CI-side gaps from Phase 1 and tightens ESLint.

- **CI (security.yml)**: added `gitleaks` (binary install, avoids gitleaks-action's org-licensing dependency) and `OSV-Scanner` jobs on every push/PR; added `cron: '0 6 * * 1'` so the previously-gated OWASP Dependency-Check and license-check jobs actually fire weekly. Normalized `node-version` to `.nvmrc`.
- **CI (docs.yml)**: new workflow running `lychee` on PRs that touch `.md` files and on a weekly schedule.
- **ESLint**: promoted `warn` → `error` for rules the codebase already passes clean (`sonarjs/prefer-immediate-return`, `prefer-single-boolean-return`, `unicorn/explicit-length-check`, `promise/catch-or-return`, `security/detect-non-literal-regexp`, `detect-unsafe-regex`, the `jsdoc/check-*` family). Re-enabled `sonarjs/no-collapsible-if` with two test-site fixes.
- **ADR 0002**: documents what landed and the architectural blocker for the contentScript.js modularization (the remaining Phase-2 acceptance-criteria item).

### What's deferred — contentScript.js modularization (Phase 2b)

Refactoring `contentScript.js` requires reconciling a pre-existing source-of-truth duplication first:

- `src/contentScript.js` (3399 lines) is what Jest loads.
- `extension-package/contentScript.js` (3195 lines) is what `scripts/build.js` ships.
- They differ by ~678 lines of diff.
- `npm run build` copies from `src/`; `npm run build:all` copies from `extension-package/`.
- `src/modules/{config,overlayManager,state}.js` exist but the runtime extension never loads them — they only back the test suite.

Splitting `contentScript.js` while two diverged primary copies exist would either widen the drift or silently lose changes. The modularization is filed as Phase 2b pending an ADR picking a canonical source tree + reconciliation pass. Full reasoning in `docs/adr/0002-tooling-phase-2.md`.

## Test plan

- [x] `npm run lint:check` passes (no warnings, no errors)
- [x] `npm test` passes — 263/263
- [x] Verify the two new security jobs (gitleaks, OSV-Scanner) and the new docs workflow are syntactically valid YAML
- [ ] Watch the first scheduled run of `security.yml` and `docs.yml` (next Monday) to confirm OWASP/license-check + lychee actually fire on schedule