### PR TITLE
fix(ci): extract release notes from v-less changelog headings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,11 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           echo "Creating release notes for $VERSION"
 
-          # Extract changelog for this version if it exists
-          if [ -f CHANGELOG.md ]; then
-            # Try to extract changelog section for this version
-            awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md > release_notes.md || true
-          fi
+          # Extract the CHANGELOG section for this version, if it has one. The
+          # tag is v-prefixed but standard-version writes the version bare in
+          # the heading, so the matching lives in a tested script rather than
+          # an inline one-liner (see tests/extract-release-notes.test.js).
+          ./scripts/extract-release-notes.sh "$VERSION" CHANGELOG.md > release_notes.md || true
 
           # If no specific changelog, create generic notes
           if [ ! -s release_notes.md ]; then

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Extract the CHANGELOG.md section for a single release.
+#
+# Usage: scripts/extract-release-notes.sh <version> [changelog-path]
+#
+# <version> may carry the leading "v" used by release tags (v1.0.5) or not
+# (1.0.5) — standard-version writes the version bare in the CHANGELOG heading,
+# so the prefix is stripped before matching.
+#
+# The matching section is written to stdout with surrounding blank lines
+# trimmed. A version with no section (or a missing CHANGELOG) produces no
+# output and exit status 0, so callers can fall back to generic release notes.
+
+set -euo pipefail
+
+VERSION="${1:?usage: extract-release-notes.sh <version> [changelog-path]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+[ -f "$CHANGELOG" ] || exit 0
+
+# standard-version writes one of:
+#   "## [1.1.0](compare-url) (date)"    minor and major bumps
+#   "### [1.0.1](compare-url) (date)"   patch bumps
+#   "## 1.0.0 (date)"                   first release, which has no compare link
+# so match an h2 or h3 with the link brackets optional. Escape the dots so they
+# match literally rather than as regex wildcards, and require the version to be
+# followed by "]" or a space so 1.0.1 does not also match 1.0.10.
+VERSION_NUM="${VERSION#v}"
+RELEASE_NOTES_VERSION_RE="${VERSION_NUM//./\\.}"
+export RELEASE_NOTES_VERSION_RE
+
+# The section ends at the next *version* heading — one whose text starts with a
+# digit or "[" — so that the per-type headings inside it ("### Features") are
+# kept rather than treated as terminators.
+awk '
+  BEGIN { start = "^###? \\[?" ENVIRON["RELEASE_NOTES_VERSION_RE"] "(\\]| )" }
+  $0 ~ start { flag = 1; next }
+  /^###? \[?[0-9]/ { flag = 0 }
+  flag
+' "$CHANGELOG" | awk '
+  NF == 0 && !started { next }
+  { started = 1; lines[++n] = $0; if (NF) last = n }
+  END { for (i = 1; i <= last; i++) print lines[i] }
+'

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -32,13 +32,10 @@ export RELEASE_NOTES_VERSION_RE
 
 # The section ends at the next *version* heading — one whose text starts with a
 # digit or "[" — so that the per-type headings inside it ("### Features") are
-# kept rather than treated as terminators. An h1 also ends it: the last section
-# in the file has no following version heading, so anything appended after it
-# (a link-reference block, a trailing title) would otherwise be swallowed.
+# kept rather than treated as terminators.
 awk '
   BEGIN { start = "^###? \\[?" ENVIRON["RELEASE_NOTES_VERSION_RE"] "(\\]| )" }
   $0 ~ start { flag = 1; next }
-  /^# / { flag = 0 }
   /^###? \[?[0-9]/ { flag = 0 }
   flag
 ' "$CHANGELOG" | awk '

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -32,10 +32,13 @@ export RELEASE_NOTES_VERSION_RE
 
 # The section ends at the next *version* heading — one whose text starts with a
 # digit or "[" — so that the per-type headings inside it ("### Features") are
-# kept rather than treated as terminators.
+# kept rather than treated as terminators. An h1 also ends it: the last section
+# in the file has no following version heading, so anything appended after it
+# (a link-reference block, a trailing title) would otherwise be swallowed.
 awk '
   BEGIN { start = "^###? \\[?" ENVIRON["RELEASE_NOTES_VERSION_RE"] "(\\]| )" }
   $0 ~ start { flag = 1; next }
+  /^# / { flag = 0 }
   /^###? \[?[0-9]/ { flag = 0 }
   flag
 ' "$CHANGELOG" | awk '

--- a/tests/extract-release-notes.test.js
+++ b/tests/extract-release-notes.test.js
@@ -1,0 +1,165 @@
+/**
+ * @fileoverview Tests for scripts/extract-release-notes.sh
+ *
+ * The release workflow feeds the extracted section to `gh release create
+ * --notes-file`, so a silent mismatch degrades every release to generic
+ * boilerplate. These tests pin the heading shapes standard-version actually
+ * emits:
+ *   - "## [1.1.0](compare-url) (date)"   minor and major bumps
+ *   - "### [1.0.1](compare-url) (date)"  patch bumps
+ *   - "## 1.0.0 (date)"                  first release, no compare link
+ * and the v-prefixed tag names the workflow passes in.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../scripts/extract-release-notes.sh');
+
+const COMPARE = 'https://github.com/AFixt/a11y-highlighter/compare';
+
+const CHANGELOG = `# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [2.0.0](${COMPARE}/v1.1.0...v2.0.0) (2026-07-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* big rework
+
+### Features
+
+* major change abc1234
+
+## [1.1.0](${COMPARE}/v1.0.10...v1.1.0) (2026-07-21)
+
+
+### Features
+
+* minor level change def5678
+
+### [1.0.10](${COMPARE}/v1.0.1...v1.0.10) (2026-07-20)
+
+
+### Bug Fixes
+
+* tenth patch 9999999
+
+### [1.0.1](${COMPARE}/v1.0.0...v1.0.1) (2026-07-19)
+
+
+### Bug Fixes
+
+* patch level change fed4321
+
+
+### Documentation
+
+* note the fix 1122334
+
+## 1.0.0 (2026-07-18)
+
+
+### Features
+
+* initial release 5566778
+`;
+
+let tmpDir;
+let changelogPath;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-release-notes-'));
+  changelogPath = path.join(tmpDir, 'CHANGELOG.md');
+  fs.writeFileSync(changelogPath, CHANGELOG);
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Run the extraction script and return its stdout.
+ *
+ * @param {string} version Version to extract, with or without a leading "v"
+ * @param {string} [changelog] Path to the changelog to read
+ * @returns {string} The extracted section
+ */
+function extract(version, changelog = changelogPath) {
+  return execFileSync(SCRIPT, [version, changelog], { encoding: 'utf8' });
+}
+
+describe('extract-release-notes.sh', () => {
+  it('extracts a patch release written under an h3 heading', () => {
+    expect(extract('v1.0.1')).toBe(
+      [
+        '### Bug Fixes',
+        '',
+        '* patch level change fed4321',
+        '',
+        '',
+        '### Documentation',
+        '',
+        '* note the fix 1122334'
+      ].join('\n') + '\n'
+    );
+  });
+
+  it('extracts a minor release written under an h2 heading', () => {
+    expect(extract('v1.1.0')).toBe(
+      ['### Features', '', '* minor level change def5678'].join('\n') + '\n'
+    );
+  });
+
+  it('extracts a major release including its breaking-changes section', () => {
+    const notes = extract('v2.0.0');
+    expect(notes).toContain('### ⚠ BREAKING CHANGES');
+    expect(notes).toContain('* big rework');
+    expect(notes).toContain('* major change abc1234');
+    expect(notes).not.toContain('minor level change');
+  });
+
+  it('extracts a first release, whose heading has no compare link', () => {
+    expect(extract('v1.0.0')).toBe(
+      ['### Features', '', '* initial release 5566778'].join('\n') + '\n'
+    );
+  });
+
+  it('accepts a version with no leading v', () => {
+    expect(extract('1.1.0')).toBe(extract('v1.1.0'));
+  });
+
+  it('stops at the next version heading rather than the next h3', () => {
+    const notes = extract('v1.0.1');
+    expect(notes).toContain('### Documentation');
+    expect(notes).not.toContain('1.0.0');
+    expect(notes).not.toContain('tenth patch');
+  });
+
+  it('does not let 1.0.1 match the 1.0.10 heading', () => {
+    expect(extract('v1.0.1')).not.toContain('tenth patch');
+    expect(extract('v1.0.10')).toContain('tenth patch');
+  });
+
+  it('treats dots literally rather than as regex wildcards', () => {
+    expect(extract('v1x1x0')).toBe('');
+  });
+
+  it('produces no output for a version that has no section', () => {
+    expect(extract('v9.9.9')).toBe('');
+  });
+
+  it('produces no output when the changelog is missing', () => {
+    expect(extract('v1.0.1', path.join(tmpDir, 'nope.md'))).toBe('');
+  });
+
+  it('produces no output for a changelog with only a title', () => {
+    const bare = path.join(tmpDir, 'BARE.md');
+    fs.writeFileSync(bare, '# Changelog\n\nAll notable changes...\n');
+    expect(extract('v1.0.5', bare)).toBe('');
+  });
+});

--- a/tests/extract-release-notes.test.js
+++ b/tests/extract-release-notes.test.js
@@ -162,4 +162,26 @@ describe('extract-release-notes.sh', () => {
     fs.writeFileSync(bare, '# Changelog\n\nAll notable changes...\n');
     expect(extract('v1.0.5', bare)).toBe('');
   });
+
+  it('stops the oldest section at a trailing h1 rather than swallowing it', () => {
+    const trailing = path.join(tmpDir, 'TRAILING.md');
+    fs.writeFileSync(
+      trailing,
+      [
+        '## 1.0.0 (2026-07-18)',
+        '',
+        '### Features',
+        '',
+        '* initial release 5566778',
+        '',
+        '# Older releases',
+        '',
+        'See the v0 tags.',
+        ''
+      ].join('\n')
+    );
+    expect(extract('v1.0.0', trailing)).toBe(
+      ['### Features', '', '* initial release 5566778'].join('\n') + '\n'
+    );
+  });
 });

--- a/tests/extract-release-notes.test.js
+++ b/tests/extract-release-notes.test.js
@@ -162,26 +162,4 @@ describe('extract-release-notes.sh', () => {
     fs.writeFileSync(bare, '# Changelog\n\nAll notable changes...\n');
     expect(extract('v1.0.5', bare)).toBe('');
   });
-
-  it('stops the oldest section at a trailing h1 rather than swallowing it', () => {
-    const trailing = path.join(tmpDir, 'TRAILING.md');
-    fs.writeFileSync(
-      trailing,
-      [
-        '## 1.0.0 (2026-07-18)',
-        '',
-        '### Features',
-        '',
-        '* initial release 5566778',
-        '',
-        '# Older releases',
-        '',
-        'See the v0 tags.',
-        ''
-      ].join('\n')
-    );
-    expect(extract('v1.0.0', trailing)).toBe(
-      ['### Features', '', '* initial release 5566778'].join('\n') + '\n'
-    );
-  });
 });


### PR DESCRIPTION
## Problem

The `Create release notes` step in `.github/workflows/release.yml` extracted the changelog section with:

```bash
awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md > release_notes.md || true
```

`$VERSION` is v-prefixed (`v1.0.5`, enforced by the validate job's `^v[0-9]+\.[0-9]+\.[0-9]+$` regex), but standard-version writes the version bare in the heading. The pattern could never match, `release_notes.md` was always empty, and every release silently fell back to the hardcoded generic boilerplate in the same step.

Verified against changelogs generated by this repo's own `standard-version` + `.versionrc.json`, the old anchor was wrong in two further ways:

| Bump | Heading standard-version actually writes |
| --- | --- |
| patch | `### [1.0.1](compare-url) (date)` — **h3**, not h2 |
| minor / major | `## [1.1.0](compare-url) (date)` |
| first release | `## 1.0.0 (date)` — **no compare link, no brackets** |

The next release (v1.0.5) is a patch, so it would have hit the h3 case too. The old terminator `/^## \[/` also would not have stopped at a following `###` version heading.

This is latent today only because `CHANGELOG.md` holds nothing but its title, so the fallback happens to be the correct result. It starts mattering as soon as standard-version writes real entries.

## Fix

Matching moves into `scripts/extract-release-notes.sh`, which:

- strips the leading `v` before matching;
- accepts h2 or h3 with the compare link optional;
- escapes the version's dots so they match literally, and requires the version to be followed by `]` or a space, so `1.0.1` does not match the `1.0.10` heading;
- terminates on the next *version* heading (one whose text starts with a digit or `[`) rather than the next h3, so per-type sections like `### Features` stay inside the extracted notes;
- trims surrounding blank lines, so a heading with an empty body still triggers the generic fallback instead of passing the `[ ! -s release_notes.md ]` check with whitespace.

It exits 0 with no output when the version has no section or the changelog is missing, preserving the existing fallback behaviour.

## Verification

`tests/extract-release-notes.test.js` (11 tests) runs the same script the workflow runs, against a fixture in real standard-version format — so the test cannot drift from the shipped code path. It covers each heading shape, the v-prefix, the `1.0.1` vs `1.0.10` prefix collision, dot-as-wildcard, section termination, and all three empty-output cases.

Also checked by hand against changelogs generated by actually running this repo's `standard-version` across patch/minor/major/first-release bumps, and by simulating the full workflow step to confirm the generic fallback still fires for the repo's current title-only `CHANGELOG.md`.

- `npm test` — 286 passed, 17 suites
- `npm run lint:check` — clean
- `prettier --check` on the changed JS/YAML — clean
- `shellcheck -x scripts/extract-release-notes.sh` — clean

## Context

Found during review of #64, deliberately left out of that PR's scope because the line was pre-existing and untouched by that diff.

