### PR TITLE
ci: gate npm audit on production deps and surface dev findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run npm audit
-        run: npm audit --audit-level moderate
-        continue-on-error: true
+      # Gating: production dependencies are what ship to users, so any
+      # high/critical advisory there must block. The extension currently has
+      # zero production dependencies, so this is free today and becomes a real
+      # gate the moment a runtime dependency is introduced.
+      - name: Run npm audit (production dependencies)
+        run: npm audit --omit=dev --audit-level=high
+
+      # Non-gating: dev-only advisories affect the build toolchain, not the
+      # shipped extension, so they must not block PRs. They are written to the
+      # job summary so they are visible on the run page instead of buried in
+      # log output behind a green check.
+      - name: Run npm audit (all dependencies, report only)
+        if: always()
+        run: |
+          npm audit --audit-level=moderate > audit.txt 2>&1 && status=0 || status=$?
+          {
+            echo "### npm audit (dev + production)"
+            echo
+            if [ "$status" -eq 0 ]; then
+              echo "No advisories at moderate or above."
+            else
+              echo "Advisories found. These are **dev-only** unless the"
+              echo "production audit step above also failed."
+              echo
+              echo '```'
+              cat audit.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat audit.txt
 
       - name: Run security scan with njsscan
         uses: ajinabraham/njsscan-action@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,10 +135,16 @@ jobs:
 
       - name: Open or update tracking issue
         uses: actions/github-script@v8
+        # Pass the count through the environment rather than interpolating
+        # ${{ }} into the script body: expression interpolation is substituted
+        # as raw text before the script is parsed, so it is the standard
+        # script-injection vector even when the current source is trusted.
+        env:
+          AUDIT_TOTAL: ${{ steps.audit.outputs.total }}
         with:
           script: |
             const fs = require('fs');
-            const total = Number('${{ steps.audit.outputs.total }}');
+            const total = Number(process.env.AUDIT_TOTAL);
             const title = 'chore(security): npm audit findings (dev dependencies)';
             // Look the issue up by label rather than via the search API: search
             // is eventually consistent, so a freshly opened issue can be missed

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,19 +33,155 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run npm audit
-        run: npm audit --audit-level=high
-        continue-on-error: true
+      # Gating: only production dependencies ship to users. See ci.yml for the
+      # rationale — this is the one audit result that warrants failing a build.
+      - name: Run npm audit (production dependencies)
+        run: npm audit --omit=dev --audit-level=high
+
+      # Non-gating: dev-toolchain advisories are reported, not enforced.
+      - name: Run npm audit (all dependencies, report only)
+        if: always()
+        run: |
+          npm audit --audit-level=high > audit.txt 2>&1 && status=0 || status=$?
+          {
+            echo "### npm audit (dev + production)"
+            echo
+            if [ "$status" -eq 0 ]; then
+              echo "No advisories at high or above."
+            else
+              echo "Advisories found (dev-only unless the production step failed)."
+              echo
+              echo '```'
+              cat audit.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat audit.txt
 
       - name: Run npm audit (JSON output)
+        if: always()
         run: npm audit --json > npm-audit-results.json || true
 
       - name: Upload audit results
         uses: actions/upload-artifact@v6
+        if: always()
         with:
           name: npm-audit-results
           path: npm-audit-results.json
           retention-days: 30
+
+  # Dev-dependency advisories are deliberately non-gating, which means nothing
+  # about them reaches a human on a normal PR. This weekly job is the mechanism
+  # that surfaces them: it opens (or refreshes) a single tracking issue so the
+  # backlog stays visible, and closes it once the tree is clean.
+  audit-report:
+    name: Report audit findings
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Collect audit summary
+        id: audit
+        run: |
+          npm audit --json > audit.json 2>/dev/null || true
+          node -e "
+            const fs = require('fs');
+            const a = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+            const m = a.metadata.vulnerabilities;
+            const total = m.critical + m.high + m.moderate + m.low;
+            const lines = [];
+            for (const [name, v] of Object.entries(a.vulnerabilities || {})) {
+              const fix = v.fixAvailable === false
+                ? 'no fix available'
+                : v.fixAvailable === true
+                  ? 'non-breaking fix'
+                  : \`requires \${v.fixAvailable.name}@\${v.fixAvailable.version} (major)\`;
+              lines.push(\`| \${name} | \${v.severity} | \${fix} |\`);
+            }
+            const body = [
+              \`Weekly \\\`npm audit\\\` found **\${total}** advisories \` +
+                \`(\${m.critical} critical, \${m.high} high, \${m.moderate} moderate, \${m.low} low).\`,
+              '',
+              'This extension ships **zero production dependencies**, so these are',
+              'dev-toolchain only and do not affect published builds. They are tracked',
+              'here because the PR-time audit steps are intentionally non-gating for',
+              'dev dependencies.',
+              '',
+              '| Package | Severity | Fix |',
+              '| --- | --- | --- |',
+              ...lines,
+              '',
+              \`Run: \${process.env.RUN_URL}\`,
+            ].join('\n');
+            fs.writeFileSync('audit-body.md', body);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, \`total=\${total}\n\`);
+          "
+          cat audit-body.md >> "$GITHUB_STEP_SUMMARY"
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Open or update tracking issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const total = Number('${{ steps.audit.outputs.total }}');
+            const title = 'chore(security): npm audit findings (dev dependencies)';
+            // Look the issue up by label rather than via the search API: search
+            // is eventually consistent, so a freshly opened issue can be missed
+            // and duplicated on the next run.
+            const found = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              state: 'open',
+              labels: 'npm-audit',
+              per_page: 100,
+            });
+            const existing = found.find((i) => i.title === title && !i.pull_request);
+
+            if (total === 0) {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: existing.number,
+                  body: 'npm audit is now clean. Closing.',
+                });
+                await github.rest.issues.update({
+                  ...context.repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                });
+              }
+              return;
+            }
+
+            const body = fs.readFileSync('audit-body.md', 'utf8');
+            if (existing) {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                ...context.repo,
+                title,
+                body,
+                labels: ['security', 'dependencies', 'npm-audit'],
+              });
+            }
 
   # Secret scanning (every push/PR) — installs gitleaks binary directly to
   # avoid the gitleaks-action org-licensing dependency.


### PR DESCRIPTION
Independent of #67/#68/#69 — touches only workflow files, no dependency changes. Can merge in any order.

## The problem

Both audit steps were `continue-on-error: true`:

- `.github/workflows/ci.yml` — `npm audit --audit-level moderate`
- `.github/workflows/security.yml` — `npm audit --audit-level=high`

So the "NPM Audit" and "Security Scan" checks reported success regardless of findings. That's how 20 advisories, including 2 critical, accumulated without anyone seeing them.

## Why not just make them gating

Blanket gating is the wrong correction. This extension ships **zero production dependencies** (`npm ls --omit=dev` is empty), so every current advisory is dev-toolchain only and cannot reach users. Failing PRs on them would train reviewers to ignore the check — which is the same failure mode, just louder. And some had no fix available at all, so the check would have been permanently red through no fault of any PR author.

## What this does instead — split the two concerns

**Gating:** `npm audit --omit=dev --audit-level=high`, no `continue-on-error`. Passes trivially today, and starts enforcing the moment a runtime dependency is introduced — the case that actually matters for a published extension.

**Reporting:** the full dev-inclusive audit stays non-gating but now writes to `$GITHUB_STEP_SUMMARY`, so findings appear on the run page instead of only in log output behind a green check.

**Weekly tracking:** a new `audit-report` job (schedule + `workflow_dispatch`) opens a single tracking issue with a per-package severity and fix-availability table, refreshes it in place on later runs, and closes it once the tree is clean. This is the mechanism that keeps deliberately non-gating findings visible.

## Two implementation notes for review

I used `actions/github-script` rather than the `peter-evans/create-issue-from-file` pattern already in `docs.yml`. A weekly job needs dedupe-and-update; the docs.yml approach opens a fresh issue every Monday. `github-script@v8` matches the version already used in `dependabot-auto-merge.yml.disabled`.

The existing issue is located by an `npm-audit` label via `issues.listForRepo` rather than the search API. Search is eventually consistent, so a freshly opened issue can be missed on the next run and duplicated.

The `audit-report` job scopes `issues: write` to itself rather than widening the workflow-level permissions.

## Verification

Both workflows parse. The gating command exits 0 against the current tree while the full audit exits 1 — confirming the gate is meaningful but non-blocking today, as intended. The report script was executed against the real 20-advisory tree (produces the correct table) and against a clean fixture (emits `total=0`, which drives the issue-closing branch). Prettier clean.

## Related, not fixed here

`.github/workflows/ci.yml` line 38 has `lint:md` at `continue-on-error: true` — the same invisibility problem one job over. Left alone as out of scope, but worth a follow-up: markdown lint failures currently also report green.