### PR TITLE
fix(ci): upload coverage with the correct codecov input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,6 +50,26 @@ jobs:
 
           echo "All workflow files are valid"
 
+      # The checks above only cover YAML syntax and the presence of top-level
+      # keys, so they cannot catch a misspelled action input — which is how
+      # `file:` instead of `files:` silently disabled the Codecov upload for
+      # months (#71). actionlint validates action inputs, expression syntax,
+      # and (via its bundled shellcheck) the inline `run:` scripts.
+      #
+      # Pinned rather than tracking latest: this gates the build, so the
+      # version is the one whose output was verified against these workflows.
+      # Bumping it is a deliberate change, not a silent one.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+        run: |
+          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin actionlint
+          actionlint --version
+
+      - name: Run actionlint
+        run: actionlint -color
+
   ci-check:
     name: CI Readiness Check
     runs-on: ubuntu-latest
@@ -61,11 +81,11 @@ jobs:
         id: detect
         run: |
           if [ -f "package.json" ]; then
-            echo "type=node" >> $GITHUB_OUTPUT
+            echo "type=node" >> "$GITHUB_OUTPUT"
           elif [ -f "requirements.txt" ] || [ -f "pyproject.toml" ]; then
-            echo "type=python" >> $GITHUB_OUTPUT
+            echo "type=python" >> "$GITHUB_OUTPUT"
           else
-            echo "type=other" >> $GITHUB_OUTPUT
+            echo "type=other" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           else
             VERSION="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
       - name: Validate version format


### PR DESCRIPTION
Closes #71

## The bug

`codecov/codecov-action@v5` takes `files:`, not `file:`. Unknown inputs are ignored rather than rejected, and the step also sets `fail_ci_if_error: false`, so the upload has been reporting success while sending nothing from the intended path. Coverage has not been reaching Codecov.

One character:

```diff
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
```

## Preventing the next one

The `Validate GitHub Actions Workflows` job checked only YAML syntax and the presence of `on:`/`jobs:` — which cannot catch a misspelled action input. That is precisely why this survived. This PR adds `actionlint` to that job, which is what found the bug in the first place.

`actionlint` is installed from a pinned release tarball, matching the idiom `security.yml` already uses for gitleaks, rather than piping `download-actionlint.bash` from `main`.

**Pinned to 1.7.7 deliberately.** This gates the build, so the version is the one whose output I verified against these workflows. 1.7.12 exists and may report more; bumping should be a reviewed change, not something that silently turns the build red one morning.

## Prerequisite cleanup

actionlint's bundled shellcheck flagged four unquoted `$GITHUB_OUTPUT` redirections (SC2086) in `pr-check.yml` (3) and `release.yml` (1). Harmless in practice — `$GITHUB_OUTPUT` never contains whitespace — but they had to be quoted so the new check lands green rather than pre-broken.

`dependabot-auto-merge.yml.disabled` has the same pattern and is untouched: actionlint's glob and the validator's loop both match only `*.yml`/`*.yaml`.

## Verification

- `actionlint` reports **0 findings** across all workflows on this branch (was 5)
- Pinned asset confirmed to exist: `actionlint_1.7.7_linux_amd64.tar.gz`, 2,080,472 bytes
- All workflows parse; `prettier --check` clean

Note that this PR cannot prove the Codecov upload now works — that needs a run on `develop` with the token, and `fail_ci_if_error: false` will keep hiding a genuine upload failure. Worth checking a report actually lands, and deciding whether that flag should stay `false`.