### PR TITLE
fix(ci): let markdown lint and duplication checks fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,13 @@ jobs:
 
       - name: Lint Markdown
         run: npm run lint:md
-        continue-on-error: true
 
+      # lint:cpd:ci runs with --threshold 5, which overrides the threshold 0 in
+      # .jscpd.json. Duplication is currently 2.36%, so this gates with room to
+      # spare; crossing 5% should be a deliberate decision (dedupe, or raise the
+      # threshold on purpose) rather than a line in a log nobody reads.
       - name: Check for code duplication (jscpd)
         run: npm run lint:cpd:ci
-        continue-on-error: true
 
       - name: Upload lint results
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Closes #72

Both steps in the `lint` job carried `continue-on-error: true`, so the "Lint Code" check reported success no matter what they found — the same false-green shape #70 removed from the two `npm audit` steps in this same file.

```diff
       - name: Lint Markdown
         run: npm run lint:md
-        continue-on-error: true

       - name: Check for code duplication (jscpd)
         run: npm run lint:cpd:ci
-        continue-on-error: true
```

## Both already pass, so this gates without a cleanup pass

```
npm run lint:md      exit 0   18 files clean
npm run lint:cpd:ci  exit 0   duplication 2.36% against --threshold 5
```

## Correction to the issue

#72 claimed jscpd "is not currently clean". **That was wrong.** jscpd prints its clone findings to the console — which is what I misread — and then exits 0 because duplication is under the threshold. `lint:cpd:ci` passes `--threshold 5`, overriding the `"threshold": 0` in `.jscpd.json`, and the tree is at 2.36%.

Since it passes with roughly 2x headroom there was no reason to leave it advisory, so both steps are gated here rather than only the markdown one. If duplication does cross 5%, the fix should be a deliberate decision — dedupe, or raise the threshold on purpose — not a line in a log nobody reads.

The 16 existing clones (mostly shared setup in `tests/e2e/*.spec.js`) are left alone; they are well inside budget and deduping them is not this PR's job.

## Verification

Every step in the `lint` job now has `continue-on-error=False`. `lint:check`, `lint:md`, `format:check`, `build` and `lint:cpd:ci` all exit 0 on this branch.