### PR TITLE
fix(ci): repair the OWASP Dependency Check job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -248,10 +248,24 @@ jobs:
           project: ${{ github.repository }}
           path: '.'
           format: 'HTML,JSON,SARIF'
+          # Only --enableExperimental is needed. The two flags that used to be
+          # here were both wrong:
+          #
+          #   --nodeAuditAnalyzer                  does not exist; it aborted
+          #                                        the whole scan. The Node
+          #                                        Audit Analyzer is on by
+          #                                        default (--disableNodeAudit
+          #                                        turns it off).
+          #   --nodePackageSkipDevDependencies     is a bare switch, so the
+          #     false                              trailing "false" was a stray
+          #                                        argument — and the switch
+          #                                        *skips* dev dependencies,
+          #                                        the opposite of the intent.
+          #
+          # Skipping dev dependencies would make this job scan nothing at all:
+          # the extension ships zero production dependencies.
           args: >
             --enableExperimental
-            --nodeAuditAnalyzer
-            --nodePackageSkipDevDependencies false
 
       - name: Upload OWASP results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -247,7 +247,12 @@ jobs:
         with:
           project: ${{ github.repository }}
           path: '.'
-          format: 'HTML,JSON,SARIF'
+          # `--format` takes a single value, not a comma-separated list, and
+          # the action offers no way to repeat it — 'HTML,JSON,SARIF' was
+          # rejected outright. 'ALL' is the supported way to get more than one,
+          # and it still writes dependency-check-report.sarif, which is the
+          # path the SARIF upload step below reads.
+          format: 'ALL'
           # Only --enableExperimental is needed. The two flags that used to be
           # here were both wrong:
           #


### PR DESCRIPTION
Closes #75

The job has never once succeeded. It is gated on `schedule`/`workflow_dispatch`, so it never runs on push or PR — every green CI run you have seen simply skipped it, and the Monday cron failure went unwatched.

There were **two** bugs, stacked. The second was invisible until the first was fixed.

## 1. `--nodeAuditAnalyzer` does not exist

```
Unrecognized option: --nodeAuditAnalyzer
```

The scan aborted before writing anything, so `Upload SARIF to GitHub Security` then failed with `Path does not exist: reports/dependency-check-report.sarif`.

Verified against `--advancedHelp` from the image the action actually runs (`owasp/dependency-check-action:latest`), both flags in that `args` block were wrong:

| flag | reality |
|---|---|
| `--nodeAuditAnalyzer` | not an option at all. The Node Audit Analyzer is **on by default**; only `--disableNodeAudit` exists |
| `--nodePackageSkipDevDependencies false` | a **bare switch** — usage shows `[--nodePackageSkipDevDependencies]` with no `<value>`, unlike e.g. `[--nexusUsesProxy <true/false>]`. The trailing `false` was a stray argument |

The second one matters more than it looks. The switch **skips** dev dependencies — the opposite of what the `false` was reaching for. This extension ships **zero production dependencies**, so had it ever parsed, the scan would have had nothing left to analyse.

Correct expression of the original intent is to omit the flag entirely, which is what this PR does.

## 2. `format: 'HTML,JSON,SARIF'` is not a valid format

```
An invalid 'format' of 'HTML,JSON,SARIF' was specified. Supported output formats are
HTML, XML, CSV, JSON, JUNIT, SARIF, JENKINS, GITLAB or ALL, and custom template files.
```

`--format` takes one value; multiple formats are requested by repeating the option, which this action provides no way to do. `ALL` is the supported route, and it still writes `dependency-check-report.sarif` — the exact path the SARIF upload step reads — alongside the html/json reports the artifact step collects.

## Verification

Not assumed — run for real, twice locally against the actual image and twice on CI.

**Locally**, proving the scanner both works *and* detects:

```
clean develop tree      scan completes, SARIF written,  0 results
pre-fix tree (2715d1e)  scan completes,                26 results
                        real GHSA ids: GHSA-4x5r-pxfx-6jf8 (@babel/core),
                        GHSA-pfq8-rq6v-vf5m (html-minifier),
                        GHSA-3jxr-9vmj-r5cp (brace-expansion), ...
```

Those are the same advisories `npm audit` reported on that tree, so the `0` on `develop` is a **true negative**, not a silently broken scan.

**On CI**, via `workflow_dispatch` on this branch — [run 29959123519](https://github.com/AFixt/accessibility-highlighter/actions/runs/29959123519), all six jobs green:

```
OWASP Dependency Check:          success
  Upload OWASP results:          success   (6.1 MB artifact)
  Upload SARIF to GitHub Security: success
```

and the analysis landed:

```
code scanning: tool=dependency-check  ref=refs/heads/fix/issue-75-...  results=0
```

That is the first `dependency-check` entry this repository has ever had in code scanning.

## Answering the issue's open questions

- **NVD API key: not needed.** The action passes `--noupdate` unconditionally, but the image ships with CVE data — the NVD CVE Analyzer ran and the vulnerable-tree scan matched real GHSAs against it. Worth revisiting only if results start looking stale, since freshness now depends on how often the upstream image is rebuilt.
- **Does the job earn its keep?** The issue floated deleting it. On the evidence, no — it demonstrably detects real advisories, and unlike `npm audit` it feeds the GitHub Security tab. Keeping it.

## Not addressed

`--failOnCVSS` is not set, so the job reports but never fails on findings. That is arguably right while the SARIF feeds the Security tab, but it does mean a critical CVE would not block anything. Worth a deliberate decision separately.