### PR TITLE
fix(ci): make the gitleaks and actionlint installs platform-aware

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -70,8 +70,16 @@ jobs:
           # overwrite a developer's own binary, which is what hardcoding
           # linux_amd64 into /usr/local/bin used to do when the workflow was
           # reproduced locally on macOS.
-          if [ -z "${GITHUB_ACTIONS:-}" ] && command -v actionlint >/dev/null 2>&1; then
-            echo "Not on CI; reusing installed $(actionlint --version | head -1)"
+          # Probe by running it, not with `command -v`: that only checks for an
+          # executable bit, so a binary for the wrong architecture — the exact
+          # mess this step used to create — would be "reused" and then fail in
+          # the next step. Failing the probe falls through to the download and
+          # self-heals.
+          # No pipe in the condition: under `pipefail` a SIGPIPE from the tool
+          # writing into a closed `head` would make a working binary look
+          # broken. `--version` prints three lines; keep only the first.
+          if [ -z "${GITHUB_ACTIONS:-}" ] && installed=$(actionlint --version 2>/dev/null); then
+            echo "Not on CI; reusing installed actionlint ${installed%%$'\n'*} (CI pins ${ACTIONLINT_VERSION})"
             exit 0
           fi
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -63,9 +63,41 @@ jobs:
         env:
           ACTIONLINT_VERSION: 1.7.7
         run: |
-          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin actionlint
-          actionlint --version
+          set -euo pipefail
+
+          # On CI always fetch the pinned build so the gate is reproducible.
+          # Off CI, reuse whatever is already installed: this step must never
+          # overwrite a developer's own binary, which is what hardcoding
+          # linux_amd64 into /usr/local/bin used to do when the workflow was
+          # reproduced locally on macOS.
+          if [ -z "${GITHUB_ACTIONS:-}" ] && command -v actionlint >/dev/null 2>&1; then
+            echo "Not on CI; reusing installed $(actionlint --version | head -1)"
+            exit 0
+          fi
+
+          case "$(uname -s)" in
+            Linux) os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64 | amd64) arch=amd64 ;;
+            arm64 | aarch64) arch=arm64 ;;
+            *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          bindir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ci-tools"
+          mkdir -p "$bindir"
+          # -f so an HTTP error fails here instead of piping an error page to tar.
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${os}_${arch}.tar.gz" \
+            | tar -xz -C "$bindir" actionlint
+          "$bindir/actionlint" --version
+
+          if [ -n "${GITHUB_PATH:-}" ]; then
+            echo "$bindir" >> "$GITHUB_PATH"
+          else
+            echo "Installed to $bindir; add it to PATH to run actionlint."
+          fi
 
       - name: Run actionlint
         run: actionlint -color

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -210,8 +210,13 @@ jobs:
           # overwrite a developer's own binary, which is what hardcoding
           # linux_x64 into /usr/local/bin used to do when the workflow was
           # reproduced locally on macOS.
-          if [ -z "${GITHUB_ACTIONS:-}" ] && command -v gitleaks >/dev/null 2>&1; then
-            echo "Not on CI; reusing installed gitleaks $(gitleaks version)"
+          # Probe by running it, not with `command -v`: that only checks for an
+          # executable bit, so a binary for the wrong architecture — the exact
+          # mess this step used to create — would be "reused" and then fail in
+          # the next step. Failing the probe falls through to the download and
+          # self-heals.
+          if [ -z "${GITHUB_ACTIONS:-}" ] && installed=$(gitleaks version 2>/dev/null); then
+            echo "Not on CI; reusing installed gitleaks ${installed} (CI pins ${GITLEAKS_VERSION})"
             exit 0
           fi
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -200,10 +200,45 @@ jobs:
           fetch-depth: 0
 
       - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.21.2
         run: |
-          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
-            | tar -xz -C /usr/local/bin gitleaks
-          gitleaks version
+          set -euo pipefail
+
+          # On CI always fetch the pinned build so the scan is reproducible.
+          # Off CI, reuse whatever is already installed: this step must never
+          # overwrite a developer's own binary, which is what hardcoding
+          # linux_x64 into /usr/local/bin used to do when the workflow was
+          # reproduced locally on macOS.
+          if [ -z "${GITHUB_ACTIONS:-}" ] && command -v gitleaks >/dev/null 2>&1; then
+            echo "Not on CI; reusing installed gitleaks $(gitleaks version)"
+            exit 0
+          fi
+
+          case "$(uname -s)" in
+            Linux) os=linux ;;
+            Darwin) os=darwin ;;
+            *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+          esac
+          # gitleaks spells x86_64 as "x64" in its release asset names.
+          case "$(uname -m)" in
+            x86_64 | amd64) arch=x64 ;;
+            arm64 | aarch64) arch=arm64 ;;
+            *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          bindir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ci-tools"
+          mkdir -p "$bindir"
+          # -f so an HTTP error fails here instead of piping an error page to tar.
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${os}_${arch}.tar.gz" \
+            | tar -xz -C "$bindir" gitleaks
+          "$bindir/gitleaks" version
+
+          if [ -n "${GITHUB_PATH:-}" ]; then
+            echo "$bindir" >> "$GITHUB_PATH"
+          else
+            echo "Installed to $bindir; add it to PATH to run gitleaks."
+          fi
 
       - name: Run gitleaks
         run: gitleaks detect --no-banner --redact --verbose

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:check": "eslint src/ tests/ scripts/ *.js --max-warnings 0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint:md": "markdownlint '**/*.md' --ignore node_modules --ignore coverage --ignore reports --ignore scratchpads --ignore docs/templates --ignore errors.md --ignore element-highlighting-guide.md --ignore CHANGELOG.md --ignore CLAUDE.md",
+    "lint:md": "markdownlint '**/*.md' --ignore-path .gitignore --ignore node_modules --ignore coverage --ignore reports --ignore scratchpads --ignore docs/templates --ignore CHANGELOG.md",
     "lint:cpd": "jscpd . --config .jscpd.json",
     "lint:cpd:ci": "jscpd . --config .jscpd.json --threshold 5",
     "security:audit": "npm audit",


### PR DESCRIPTION
Follow-up from #83. Both tool-install steps hardcoded a Linux tarball and extracted it straight into `/usr/local/bin`:

```bash
curl -sSL .../gitleaks_8.21.2_linux_x64.tar.gz | tar -xz -C /usr/local/bin gitleaks
```

Fine on `ubuntu-latest`, destructive anywhere else. Reproducing these workflows locally on macOS silently replaced the Homebrew `gitleaks` and `actionlint` with Linux ELF binaries, leaving both failing with `exec format error`. It's easy to miss: `tar` preserves the archive's mtime, so the clobbered files still look old — only `ctime` gives it away. This actually happened while reviewing #83.

## Changes

Both install steps now:

- **Probe the tool by running it** (not `command -v`) before reusing it. `command -v` only checks for an executable bit, so a wrong-architecture binary — the exact mess these steps used to create — would be "reused" and then fail in the next step. Failing the probe falls through to the download, so a damaged machine repairs itself.
- **Reuse a working local install only when off CI.** On CI (`$GITHUB_ACTIONS` set) the pinned version is always fetched, so the gate stays reproducible regardless of what a runner image ships. The reused version is reported next to the pinned one, since e.g. gitleaks 8.30.1 has a different rule set than the pinned 8.21.2 and "green locally" shouldn't silently imply "green on CI".
- **Resolve os/arch from `uname`** instead of assuming linux/x64, failing clearly on anything unsupported. The two projects spell x86_64 differently — gitleaks uses `x64`, actionlint `amd64`.
- **Extract into `$RUNNER_TEMP/ci-tools`** (falling back to `$TMPDIR`) and append that to `$GITHUB_PATH`, instead of writing to `/usr/local/bin`.
- **Use `curl -f`** so an HTTP error fails the step instead of piping an error page into `tar`, plus `set -euo pipefail`.

Also included (`fix(lint)`): `lint:md` now passes `--ignore-path .gitignore`. #83 gitignored the artifacts CI writes to the repo root, but markdownlint globs `**/*.md` and doesn't consult `.gitignore` — so a local CI reproduction left `audit-body.md` behind, which failed MD047 and broke `lint:md` and the pre-push hook with an error pointing at a file the developer never wrote. Same failure this PR is about: reproducing CI locally shouldn't leave the repo broken.

## Verification

Extracted both `run:` blocks and executed them on darwin/arm64 in four modes:

| Mode | Expected | Result |
| --- | --- | --- |
| Off-CI, working tools installed | reuse, no download | `reusing installed gitleaks 8.30.1 (CI pins 8.21.2)`, exit 0 |
| Off-CI, **broken wrong-arch** binary on PATH | fall through, self-heal | fetched native `Mach-O arm64` builds |
| Off-CI, no tool present | fetch native build | fetched native `Mach-O arm64` builds |
| `GITHUB_ACTIONS=true` | ignore local, fetch pinned | fetched `8.21.2` / `1.7.7`, wrote `$GITHUB_PATH` |

`/usr/local/bin/{gitleaks,actionlint}` kept **identical inode and ctime** throughout and remain the working Homebrew Mach-O builds — the specific regression this fixes.

Re-ran the real harness that caused the damage, scoped to these two jobs: **5/5 steps pass**, where 4 previously failed. `actionlint` (with bundled shellcheck) is clean on the new `run:` blocks.

For the `lint:md` change, a mutation test confirms it isn't weakened: injecting MD001/MD009/MD012 violations into a tracked ADR still fails with exit 1, and `README.md` is still linted.

No behaviour change on `ubuntu-latest`: same pinned versions, same tools, same commands. CI logs confirm both jobs fetch `linux/amd64` builds of the pinned versions.

## Known follow-ups (not done here)

- **The two install blocks are 33-of-36 lines identical**, differing only in tool name, repo path, version var, and the `x64`/`amd64` spelling — and `jscpd` won't catch the drift because `.jscpd.json` sets `format: ["javascript","json"]`, so YAML isn't scanned. A composite action under `.github/actions/` would DRY it. Left alone: the repo has no such convention yet, and abstracting over two occurrences is premature. Worth doing at a third tool.
- **No checksum verification** on either download. Pre-existing, but these lines were rewritten here. Pinning digests means 4 platform hashes × 2 tools to maintain per version bump — a maintenance burden that should be an explicit choice rather than something slipped into a fix.
