### PR TITLE
docs: document the release flow and the main back-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ The Accessibility Highlighter is a Chrome extension that identifies accessibilit
 This project follows Git Flow branching strategy. All development work must adhere to the following:
 
 ### Branch Structure
+
 - **main**: Production-ready code only. Never commit directly to main.
 - **develop**: Integration branch for features. All feature branches merge here first.
 - **feature/**: Create feature branches from develop (e.g., feature/add-keyboard-nav)
@@ -18,6 +19,7 @@ This project follows Git Flow branching strategy. All development work must adhe
 - **hotfix/**: Emergency fixes from main that bypass develop
 
 ### Workflow Rules
+
 1. Always create feature branches from develop: `git checkout -b feature/feature-name develop`
 2. Merge feature branches back to develop via pull request
 3. Create release branches from develop when ready for production
@@ -25,10 +27,23 @@ This project follows Git Flow branching strategy. All development work must adhe
 5. Create hotfix branches from main for critical production issues
 6. Merge hotfix branches to both main and develop
 
+### Releases
+
+This project promotes `develop` to `main` directly via pull request; the `release/` branch step above is not used in practice — every tag from v1.0.3 onward sits on a `Merge pull request ... from AFixt/develop` commit.
+
+1. Bump on develop with standard-version (`npm run release:patch` / `:minor` / `:major`). It updates package.json, package-lock.json, manifest.json and CHANGELOG.md, and commits as `chore(release): vX.Y.Z`.
+2. Open a `develop` → `main` pull request titled `Release vX.Y.Z`; merge once checks pass.
+3. Tag the merge commit on main and push the tag:
+   `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
+   Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds the per-browser packages and creates the GitHub release from the matching CHANGELOG section.
+4. **Merge `main` back into `develop` and push.** This is the "and develop" half of workflow rule 4, and it is easy to lose because the release-branch step is skipped. Tags are created on main, so without it no tag is reachable from develop: `git describe` on develop goes stale and standard-version diffs against a long-superseded tag, producing a changelog that re-lists already-shipped work. (This was skipped from v1.0.2 until v1.0.6.) Expect an empty content diff — if real content appears, something reached main that develop never saw.
+
 ### Commit Messages
+
 - Use conventional commit format when applicable
 - Include ticket/issue numbers if available
 - Keep messages clear and descriptive
+- Subjects must be entirely lower-case (commitlint `subject-case`), so write `fix(docs): repoint the github links`, not `fix(docs): repoint the GitHub links`
 
 ## Project Todo List
 


### PR DESCRIPTION
Follow-up to the v1.0.6 release, which surfaced a gap in this file.

## The gap

`CLAUDE.md`'s workflow rule 4 already said to merge "to both main and develop" — but it hung that rule off `release/` branches, which this project does not use. Releases promote `develop` to `main` directly (every tag from v1.0.3 onward sits on a `Merge pull request ... from AFixt/develop` commit).

The rule was live; the path it hung off of was dead. So the back-merge lapsed from v1.0.2 until v1.0.6, and the damage was invisible until something depended on it:

- No tag after v1.0.2 was reachable from `develop`, so `git describe --tags` on develop returned `v1.0.2`.
- standard-version therefore diffed the v1.0.6 changelog against **v1.0.2**, re-listing roughly 20 commits already shipped in v1.0.3–v1.0.5.

That was caught and corrected during the release; this records the flow so it isn't rediscovered next time.

## What's added

- A **Releases** section documenting the actual flow: bump on develop with standard-version → `develop` → `main` PR → tag the merge commit → tag push triggers `release.yml`, which builds the per-browser packages and creates the GitHub release from the CHANGELOG section.
- **The back-merge as an explicit numbered step**, with the check that makes it safe (expect an empty content diff — real content means something reached `main` that `develop` never saw) and the symptom of skipping it.
- A **commit-message bullet** on commitlint's lower-case `subject-case` rule, which rejected two otherwise well-formed subjects during the release and was documented nowhere.

The same back-merge step was added to the `bump-and-go` skill, along with a precondition check that catches an *already*-skipped back-merge before it corrupts a changelog.

## Note on the diff

Six of the added lines are blank lines that `markdownlint --fix` inserted around pre-existing headings and lists. lint-staged applies the same fix on commit; I ran it up front so the change is visible here rather than appearing silently.