### PR TITLE
harden: sanitize child_process call in build.js...

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const EXTENSION_DIR = path.join(ROOT_DIR, 'src');
@@ -83,7 +83,8 @@ function createZip(sourceDir, outputPath) {
   }
 
   // Create zip (exclude .DS_Store files)
-  execSync(`cd "${sourceDir}" && zip -r "${outputPath}" . -x "*.DS_Store"`, {
+  spawnSync('zip', ['-r', outputPath, '.', '-x', '*.DS_Store'], {
+    cwd: sourceDir,
     stdio: 'inherit'
   });
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -82,11 +82,21 @@ function createZip(sourceDir, outputPath) {
     fs.unlinkSync(outputPath);
   }
 
-  // Create zip (exclude .DS_Store files)
-  spawnSync('zip', ['-r', outputPath, '.', '-x', '*.DS_Store'], {
+  // Create zip (exclude .DS_Store files).
+  // spawnSync with an argument array runs zip directly (no shell), so
+  // sourceDir/outputPath cannot inject shell commands. Unlike execSync,
+  // spawnSync does not throw on failure — check the result so a missing or
+  // failing zip aborts the build instead of silently producing no archive.
+  const result = spawnSync('zip', ['-r', outputPath, '.', '-x', '*.DS_Store'], {
     cwd: sourceDir,
     stdio: 'inherit'
   });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`zip exited with status ${result.status} while creating ${outputPath}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/build.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/build.js:86` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `outputPath`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/build.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
