### PR TITLE
ci: add Action Pin Freshness check (workflow_dispatch)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -366,3 +366,29 @@ jobs:
           name: license-report
           path: licenses.json
           retention-days: 90
+
+  # Reports action pins whose tag has moved since they were pinned.
+  #
+  # Pinning to a SHA closed a supply-chain hole and opened a maintenance job in
+  # exchange: a pinned SHA is immune to a hijacked tag and equally immune to the
+  # fixes that tag would have carried. Dependabot used to own refreshing them and
+  # is banned under the no-scheduled-Actions policy, so this is the mechanism.
+  #
+  # workflow_dispatch only, deliberately. It reports on the state of the world
+  # rather than on a change, so gating a PR with it would fail builds that
+  # introduced nothing — the drift arrives when upstream moves a tag. Run it when
+  # someone is ready to read release notes and act.
+  #
+  # Plain node, no npm ci and no NPM_TOKEN: the script uses only node builtins.
+  action-pins:
+    name: Action Pin Freshness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Check action pin freshness
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-action-pins.js

--- a/scripts/action-pins.js
+++ b/scripts/action-pins.js
@@ -1,0 +1,211 @@
+/**
+ * Parses and classifies the pinned GitHub Actions references in
+ * .github/workflows. Pure logic only — no I/O — so it is unit-testable
+ * (tests/unit/action-pins.test.js). The CLI wrapper that resolves tags against
+ * the GitHub API is scripts/check-action-pins.js.
+ *
+ * Why this exists: every action reference here is pinned to a commit SHA so a
+ * tag cannot be silently repointed under us. That closed a real supply-chain
+ * hole and created an unowned maintenance job in exchange — a pinned SHA is
+ * immune to a hijacked tag, and equally immune to the security fixes that tag
+ * would have carried. Dependabot used to own refreshing the pins; it is now
+ * banned repo-wide along with every other scheduled automation (#45),
+ * so this check is the mechanism instead of it.
+ *
+ * The comparison is between the pinned SHA and the tag recorded in the
+ * trailing comment (`@<sha> # v4.4.0`). Actions publish fixes by moving their
+ * floating tag, so "the tag now points somewhere else" is exactly the signal
+ * worth having.
+ *
+ * Known limitation: this cannot see a new major. A repository pinned to v4
+ * keeps resolving v4 even after upstream ships v5. Dependabot would have
+ * caught that; a human reading release notes still has to.
+ *
+ * Ported from lexic-a11y's scripts/action-pins.mjs (itself from a11y-mcp's
+ * mcp-server/scripts/actionPins.ts). Rewritten as CommonJS to match this
+ * repository's scripts/ idiom — see scripts/check-sarif.js. The parsing and
+ * classification logic is unchanged, so a fix in any of the three ports
+ * applies to the others.
+ */
+
+/**
+ * @typedef {object} ActionPin
+ * @property {string} file Workflow file the reference was found in.
+ * @property {number} line 1-based line number, so output pastes into an editor.
+ * @property {string} owner GitHub owner of the action.
+ * @property {string} repo Repository name of the action.
+ * @property {string} [sha] The 40-char commit SHA the workflow pins, if pinned.
+ * @property {string} [tag] The version recorded in the trailing comment.
+ * @property {string} ref The raw ref after `@`, whether or not it is a SHA.
+ */
+
+/**
+ * @typedef {(
+ *   | {kind: 'current'}
+ *   | {kind: 'stale', expected: string}
+ *   | {kind: 'unknown', reason: string}
+ * )} PinStatus
+ * current: pinned SHA matches what the tag resolves to today.
+ * stale: the tag has moved since this was pinned.
+ * unknown: nothing to compare against — no SHA, no tag comment, or the tag
+ * could not be resolved.
+ */
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * Split a `uses:` line into its reference and any trailing `# tag` comment.
+ *
+ * String operations rather than a regex, for the same reason as
+ * `splitActionRef` below: every pattern that expressed this concisely was
+ * rejected by `security/detect-unsafe-regex` under this repository's lint
+ * config. Scanning for the delimiters directly is linear by construction, so
+ * there is nothing to be conservative about.
+ *
+ * @param {string} rawLine One line of a workflow file.
+ * @returns {{value: string, tag?: string} | undefined} The reference and its tag comment, when the line is a `uses:`.
+ */
+function splitUsesLine(rawLine) {
+  let rest = rawLine.trim();
+  if (rest.startsWith('- ')) {
+    rest = rest.slice(2).trim();
+  }
+  if (!rest.startsWith('uses:')) {
+    return undefined;
+  }
+
+  rest = rest.slice('uses:'.length).trim();
+  if (rest === '') {
+    return undefined;
+  }
+
+  const hash = rest.indexOf('#');
+  const value = (hash === -1 ? rest : rest.slice(0, hash)).trim();
+  const comment = hash === -1 ? '' : rest.slice(hash + 1).trim();
+  if (value === '') {
+    return undefined;
+  }
+
+  // Only the first word of the comment is the tag; anything after it is prose.
+  const [tag] = comment.split(/\s/, 1);
+  return tag ? { value, tag } : { value };
+}
+
+/**
+ * Split `owner/repo[/subpath]@ref` into its parts.
+ *
+ * Done with string operations rather than one regex on purpose. The upstream
+ * ports match the whole thing in a single pattern whose optional `/subpath`
+ * group overlaps the preceding `owner/repo`, which is ambiguous enough that
+ * `security/detect-unsafe-regex` and `sonarjs/regex-complexity` both reject it
+ * under this repository's lint config. Splitting on the last `@` and then on
+ * `/` is unambiguous, linear, and easier to read than the pattern it replaces.
+ *
+ * Local (`./.github/actions/x`) and Docker (`docker://…`) references have no
+ * upstream tag to compare against, so they are skipped here.
+ *
+ * @param {string} value The raw value following `uses:`.
+ * @returns {{owner: string, repo: string, ref: string} | undefined} The parts, when it is an upstream action reference.
+ */
+function splitActionRef(value) {
+  if (value.startsWith('./') || value.startsWith('docker://')) {
+    return undefined;
+  }
+
+  const at = value.lastIndexOf('@');
+  if (at <= 0 || at === value.length - 1) {
+    return undefined;
+  }
+
+  const [owner, repo] = value.slice(0, at).split('/');
+  if (!owner || !repo) {
+    return undefined;
+  }
+
+  return { owner, repo, ref: value.slice(at + 1) };
+}
+
+/**
+ * Pull every action reference out of one workflow file's text.
+ *
+ * @param {string} text The workflow file contents.
+ * @param {string} file The file name, recorded on each pin for reporting.
+ * @returns {ActionPin[]} Every `uses:` reference found.
+ */
+function parseActionPins(text, file) {
+  const pins = [];
+
+  text.split('\n').forEach((rawLine, index) => {
+    const line = splitUsesLine(rawLine);
+    if (!line) {
+      return;
+    }
+
+    const parts = splitActionRef(line.value);
+    if (!parts) {
+      return;
+    }
+
+    const { owner, repo, ref } = parts;
+    const { tag } = line;
+
+    pins.push({
+      file,
+      line: index + 1,
+      owner,
+      repo,
+      ref,
+      // A tag comment on an unpinned ref is noise; only record it with a SHA.
+      ...(SHA_PATTERN.test(ref) ? { sha: ref } : {}),
+      ...(tag ? { tag } : {})
+    });
+  });
+
+  return pins;
+}
+
+/**
+ * Compare one pin against the SHA its tag resolves to upstream.
+ *
+ * `resolvedSha` is undefined when the tag could not be resolved — a deleted
+ * tag, a branch name in the comment, or a rate-limited API call. That is
+ * reported as unknown rather than stale, because "we could not check" and
+ * "this is out of date" warrant different responses.
+ *
+ * @param {ActionPin} pin The parsed reference.
+ * @param {string | undefined} resolvedSha What the tag points at today.
+ * @returns {PinStatus} How the pin compares.
+ */
+function classifyPin(pin, resolvedSha) {
+  if (!pin.sha) {
+    return {
+      kind: 'unknown',
+      reason: `not pinned to a SHA (points at "${pin.ref}")`
+    };
+  }
+
+  if (!pin.tag) {
+    return {
+      kind: 'unknown',
+      reason: 'pinned to a SHA but has no "# <tag>" comment to check it against'
+    };
+  }
+
+  if (!resolvedSha) {
+    return { kind: 'unknown', reason: `tag "${pin.tag}" could not be resolved upstream` };
+  }
+
+  return resolvedSha === pin.sha ? { kind: 'current' } : { kind: 'stale', expected: resolvedSha };
+}
+
+/**
+ * `owner/repo` — the key a tag is resolved against.
+ *
+ * @param {ActionPin} pin The parsed reference.
+ * @returns {string} The repository slug.
+ */
+function repoSlug(pin) {
+  return `${pin.owner}/${pin.repo}`;
+}
+
+module.exports = { parseActionPins, classifyPin, repoSlug };

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Reports GitHub Actions SHA pins that have drifted from the tag they claim.
+ *
+ * Dependabot used to own refreshing these pins; scheduled automation
+ * (Dependabot included) is banned repo-wide (#45), so this check is the
+ * mechanism instead. Run it via the `Action Pin Freshness` workflow_dispatch
+ * job in security.yml, or locally:
+ *
+ *   npm run security:action-pins
+ *
+ * Exit code 1 when any pin is stale — the tag has moved since it was pinned,
+ * which usually means upstream shipped a fix this repository is frozen
+ * against. References that cannot be checked (no SHA, no tag comment, or a
+ * branch pin like Dependency-Check_Action's deliberate `main` pin) are
+ * reported as unknown and do not fail the run: "we could not check" and
+ * "this is out of date" warrant different responses.
+ *
+ * Env vars:
+ *   GITHUB_TOKEN — raises the API rate limit from 60/hr to 5000/hr. Optional
+ *                  locally; supplied automatically in Actions.
+ */
+const fs = require('node:fs/promises');
+const { join } = require('node:path');
+
+const { classifyPin, parseActionPins, repoSlug } = require('./action-pins');
+
+const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
+
+const API = 'https://api.github.com';
+
+/**
+ * Request headers for the GitHub REST API.
+ *
+ * @returns {Record<string, string>} Headers, with auth when available.
+ */
+function headers() {
+  const token = process.env.GITHUB_TOKEN;
+  return {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(token ? { Authorization: `Bearer ${token}` } : {})
+  };
+}
+
+/**
+ * Resolve `owner/repo` + tag to the commit SHA it points at today.
+ *
+ * Annotated tags resolve to a tag object rather than a commit, so those need
+ * a second hop to get the commit a workflow would actually check out. Returns
+ * undefined for anything unresolvable; the caller reports that as unknown
+ * rather than treating it as drift.
+ *
+ * @param {string} slug `owner/repo`.
+ * @param {string} tag The tag name from the pin's trailing comment.
+ * @returns {Promise<string | undefined>} The commit SHA, if resolvable.
+ */
+async function resolveTag(slug, tag) {
+  const res = await fetch(`${API}/repos/${slug}/git/ref/tags/${encodeURIComponent(tag)}`, {
+    headers: headers()
+  });
+  if (!res.ok) {
+    return undefined;
+  }
+
+  const ref = await res.json();
+  if (!ref.object?.sha) {
+    return undefined;
+  }
+  if (ref.object.type !== 'tag') {
+    return ref.object.sha;
+  }
+
+  const deref = await fetch(`${API}/repos/${slug}/git/tags/${ref.object.sha}`, {
+    headers: headers()
+  });
+  if (!deref.ok) {
+    return undefined;
+  }
+
+  const annotated = await deref.json();
+  return annotated.object?.sha;
+}
+
+/*
+ * The fs calls below take a directory supplied on the command line, which is
+ * the entire job of a CLI that reads a workflows directory — the same reason
+ * scripts/check-sarif.js disables this rule. The value comes from the workflow
+ * step that invokes this script, not from anything the analysed code can
+ * influence, and the script only ever reads.
+ */
+/* eslint-disable security/detect-non-literal-fs-filename */
+
+/**
+ * Parse every workflow file in a directory into action pins.
+ *
+ * @param {string} dir The workflows directory.
+ * @returns {Promise<import('./action-pins').ActionPin[]>} All references.
+ */
+async function collectPins(dir) {
+  const entries = await fs.readdir(dir);
+  const pins = [];
+
+  for (const name of entries.filter((n) => n.endsWith('.yml') || n.endsWith('.yaml')).sort()) {
+    pins.push(...parseActionPins(await fs.readFile(join(dir, name), 'utf8'), name));
+  }
+
+  return pins;
+}
+
+/* eslint-enable security/detect-non-literal-fs-filename */
+
+/**
+ * Classify every pin, printing one line each, and bucket the ones that need
+ * attention. Split out of main() to keep that function within this
+ * repository's complexity limits.
+ *
+ * @param {import('./action-pins').ActionPin[]} pins Parsed references.
+ * @param {Map<string, string | undefined>} resolved Tag lookups, keyed `slug@tag`.
+ * @returns {{stale: string[], unknown: string[]}} Reportable lines per bucket.
+ */
+function report(pins, resolved) {
+  const stale = [];
+  const unknown = [];
+
+  for (const pin of pins) {
+    const status = classifyPin(pin, resolved.get(`${repoSlug(pin)}@${pin.tag}`));
+    const where = `${pin.file}:${pin.line}`;
+
+    if (status.kind === 'current') {
+      console.log(`  ok       ${where}  ${repoSlug(pin)}@${pin.tag}`);
+    } else if (status.kind === 'stale') {
+      stale.push(`${where}  ${repoSlug(pin)}  ${pin.tag}: ${pin.sha} -> ${status.expected}`);
+      console.log(`  STALE    ${where}  ${repoSlug(pin)}@${pin.tag}`);
+    } else {
+      unknown.push(`${where}  ${repoSlug(pin)}  ${status.reason}`);
+      console.log(`  unknown  ${where}  ${repoSlug(pin)}  ${status.reason}`);
+    }
+  }
+
+  return { stale, unknown };
+}
+
+/**
+ * Check every pin and report; exit 1 if any is stale.
+ *
+ * @returns {Promise<void>} Resolves when the report is printed.
+ */
+async function main() {
+  const dir = process.argv[2] || DEFAULT_WORKFLOW_DIR;
+  const pins = await collectPins(dir);
+
+  if (pins.length === 0) {
+    console.error(`No action references found in ${dir}`);
+    process.exit(1);
+  }
+
+  // One lookup per distinct repo+tag: the references collapse to a handful,
+  // which matters against an unauthenticated 60/hr rate limit.
+  const wanted = new Map();
+  for (const pin of pins) {
+    if (pin.sha && pin.tag) {
+      wanted.set(`${repoSlug(pin)}@${pin.tag}`, { slug: repoSlug(pin), tag: pin.tag });
+    }
+  }
+
+  const resolved = new Map();
+  await Promise.all(
+    [...wanted].map(async ([key, { slug, tag }]) => resolved.set(key, await resolveTag(slug, tag)))
+  );
+
+  const { stale, unknown } = report(pins, resolved);
+
+  console.log(
+    `\n${pins.length} references checked: ${pins.length - stale.length - unknown.length} current, ` +
+      `${stale.length} stale, ${unknown.length} unknown.`
+  );
+
+  if (unknown.length > 0) {
+    console.log('\nCould not be checked:');
+    for (const line of unknown) {
+      console.log(`  ${line}`);
+    }
+  }
+
+  if (stale.length > 0) {
+    console.log('\nStale pins — the tag has moved since these were pinned:');
+    for (const line of stale) {
+      console.log(`  ${line}`);
+    }
+    console.log(
+      '\nUpdate the SHA in the workflow, keeping the "# <tag>" comment accurate.\n' +
+        'Read the upstream release notes first — that is the review step a pinned\n' +
+        'SHA buys you, and the reason this repository pins rather than floating.'
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -84,12 +84,10 @@ async function resolveTag(slug, tag) {
 
 /*
  * The fs calls below take a directory supplied on the command line, which is
- * the entire job of a CLI that reads a workflows directory — the same reason
- * scripts/check-sarif.js disables this rule. The value comes from the workflow
- * step that invokes this script, not from anything the analysed code can
- * influence, and the script only ever reads.
+ * the entire job of a CLI that reads a workflows directory. The value comes
+ * from the workflow step that invokes this script, not from anything the
+ * analysed code can influence, and the script only ever reads.
  */
-/* eslint-disable security/detect-non-literal-fs-filename */
 
 /**
  * Parse every workflow file in a directory into action pins.
@@ -101,14 +99,12 @@ async function collectPins(dir) {
   const entries = await fs.readdir(dir);
   const pins = [];
 
-  for (const name of entries.filter((n) => n.endsWith('.yml') || n.endsWith('.yaml')).sort()) {
+  for (const name of entries.filter(n => n.endsWith('.yml') || n.endsWith('.yaml')).sort()) {
     pins.push(...parseActionPins(await fs.readFile(join(dir, name), 'utf8'), name));
   }
 
   return pins;
 }
-
-/* eslint-enable security/detect-non-literal-fs-filename */
 
 /**
  * Classify every pin, printing one line each, and bucket the ones that need
@@ -152,7 +148,8 @@ async function main() {
 
   if (pins.length === 0) {
     console.error(`No action references found in ${dir}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // One lookup per distinct repo+tag: the references collapse to a handful,
@@ -193,11 +190,13 @@ async function main() {
         'Read the upstream release notes first — that is the review step a pinned\n' +
         'SHA buys you, and the reason this repository pins rather than floating.'
     );
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 
-main().catch((err) => {
+// Failures set process.exitCode rather than calling process.exit(), so the
+// script still exits non-zero for CI without truncating pending stdout.
+main().catch(err => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## What

Adds the **Action Pin Freshness** check: `scripts/action-pins` (pure parsing/classification), `scripts/check-action-pins` (CLI that resolves each tag against the GitHub API), and a `workflow_dispatch` job in `security.yml`.

## Why

Pinning every action to a SHA closed a supply-chain hole and opened a maintenance job in exchange: a pinned SHA is immune to a hijacked tag, and equally immune to the fixes that tag would have carried. Dependabot used to own refreshing them and is banned under the no-scheduled-Actions policy — so since then, **nothing has owned it**.

Every SHA pin in this repository carries a `# <tag>` comment, so the check has something to compare against on every reference.

## Why `workflow_dispatch` only, and not in CI

It reports on the **state of the world**, not on a change. Gating a PR with it would fail builds that introduced nothing — drift arrives when upstream moves a tag, not when someone edits this repository. So it is neither on a timer (banned) nor blocking a PR (wrong signal): run it when someone is ready to read release notes and act.

**This PR cannot affect any existing pipeline.** The job runs only on manual dispatch, and the script uses only node builtins — no `npm ci`, no `NPM_TOKEN`, no new dependency.

## Provenance

Ported from `lexic-a11y`, which took it from `a11y-mcp`. Adopting the existing solution rather than adding a third design.

One deliberate improvement over both: the upstream single parsing regex has an optional `/subpath` group that overlaps the preceding `owner/repo`, which `security/detect-unsafe-regex` and `sonarjs/regex-complexity` flag. Both halves are string splits here — linear by construction, and no lint config can object.

## Verification

Validated in `AFixt/batch-scanner#51`, where it runs clean under a strict lint config (`security`, `sonarjs`, `unicorn`, `jsdoc`, prettier, `--max-warnings=0`) and is covered by 12 unit tests, mutation-checked. On its first run there it found real drift — `github/codeql-action@v4` pinned to a SHA the tag had moved off.

The job checks out and runs this repository's workflows, so the first manual dispatch is the real test here.

**Not verified in this repository:** CI cannot run — every job in the org currently fails with *"The job was not started because an Actions budget is preventing further use."* Tests are not included here because test-runner conventions vary per repo; the logic is covered upstream in `batch-scanner`.

Part of AFixt/batch-scanner#44 (step 3).