### PR TITLE
chore(npm): tighten npm publish configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -14,4 +14,3 @@ cache-min=3600
 loglevel=error
 @afixt:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@afixt/a11y-highlighter",
   "version": "1.0.6",
+  "private": true,
   "description": "The Accessibility Highlighter finds accessibility problems on a website and highlights them on the page to give a visual indication of what the problems are. It also logs errors to console and annotates the DOM.",
   "main": "src/background.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@afixt/a11y-highlighter",
   "version": "1.0.6",
-  "private": true,
   "description": "The Accessibility Highlighter finds accessibility problems on a website and highlights them on the page to give a visual indication of what the problems are. It also logs errors to console and annotates the DOM.",
   "main": "src/background.js",
   "scripts": {
@@ -59,6 +58,9 @@
     "url": "https://github.com/AFixt/accessibility-highlighter"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",


### PR DESCRIPTION
Mechanical npm publish-configuration change, part of a fleet-wide sweep.

- Removes the deprecated `always-auth` setting (npm 11 reports it as an unknown project config and ignores it).

- Makes publish visibility explicit: this package is meant to be published publicly, so `publishConfig.access` is set to `public` and a bare `npm publish` is correct without needing `--access public` on the command line.