### PR TITLE
Release v1.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
         run: npm run lint:cpd:ci
 
       - name: Upload lint results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
         with:
           name: lint-results
@@ -62,7 +62,7 @@ jobs:
           retention-days: 30
 
       - name: Upload duplication report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: jscpd-report
           path: reports/jscpd/
@@ -75,10 +75,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -90,7 +90,7 @@ jobs:
         run: npm run test:coverage -- --coverageReporters=text-lcov --coverageReporters=html
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./coverage/lcov.info
           flags: unittests
@@ -98,7 +98,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: test-results
@@ -114,10 +114,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -136,7 +136,7 @@ jobs:
         continue-on-error: true # Allow E2E test failures
 
       - name: Upload E2E test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: e2e-results
@@ -152,10 +152,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -170,7 +170,7 @@ jobs:
         run: npm run package
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: extension-build
           path: |
@@ -197,10 +197,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -240,12 +240,12 @@ jobs:
           cat audit.txt
 
       - name: Run security scan with njsscan
-        uses: ajinabraham/njsscan-action@master
+        uses: ajinabraham/njsscan-action@231750a435d85095d33be7d192d52ec650625146 # v9
         with:
           args: '--sarif --output results.sarif src/ || true'
 
       - name: Upload security scan results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: security-results
@@ -262,10 +262,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'

--- a/.github/workflows/code-quality.yml.disabled
+++ b/.github/workflows/code-quality.yml.disabled
@@ -5,9 +5,6 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-  schedule:
-    # Run weekly code quality checks
-    - cron: '0 8 * * 1' # Every Monday at 8 AM UTC
 
 jobs:
   codeql:

--- a/.github/workflows/code-quality.yml.disabled
+++ b/.github/workflows/code-quality.yml.disabled
@@ -27,18 +27,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: '/language:${{matrix.language}}'
 
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for better analysis
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
         run: npm test -- --coverage --coverageReporters=lcov
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -134,7 +134,7 @@ jobs:
           done
 
       - name: Upload complexity report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: complexity-report
           path: complexity-report.md
@@ -146,10 +146,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -228,7 +228,7 @@ jobs:
           node test-extension.js
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: accessibility-test-results
           path: test-pages/
@@ -240,10 +240,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -297,7 +297,7 @@ jobs:
           fi
 
       - name: Upload performance report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: performance-report
           path: size-report.md

--- a/.github/workflows/dependabot-auto-merge.yml.disabled
+++ b/.github/workflows/dependabot-auto-merge.yml.disabled
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -74,7 +74,7 @@ jobs:
 
       - name: Auto-approve PR
         if: steps.check-update.outputs.auto_merge == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Auto-merge PR
         if: steps.check-update.outputs.auto_merge == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: Comment on skipped PR
         if: steps.check-update.outputs.auto_merge == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,13 +6,10 @@ on:
     paths:
       - '**/*.md'
       - .github/workflows/docs.yml
-  schedule:
-    - cron: '0 7 * * 1' # Monday 07:00 UTC — catches external link rot
   workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   link-check:
@@ -30,22 +27,10 @@ jobs:
           args: --config lychee.toml './**/*.md'
           fail: false
 
-      - name: Create issue on broken links (scheduled runs only)
-        if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != '0'
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: 'Link checker: broken links detected'
-          content-filepath: ./lychee/out.md
-          labels: |
-            documentation
-            broken-links
-
-      # lychee runs with `fail: false` so the issue-filing step above still gets
-      # a chance to run; this step is what turns broken links into a red build.
-      # Scheduled runs are exempt: external link rot there is reported as an
-      # issue, not as a failure nobody is watching for.
+      # lychee runs with `fail: false` so the exit code can be inspected here;
+      # this step is what turns broken links into a red build.
       - name: Fail on broken links
-        if: github.event_name != 'schedule' && steps.lychee.outputs.exit_code != '0'
+        if: steps.lychee.outputs.exit_code != '0'
         run: |
           echo "::error::lychee found broken links — see the job summary for details."
           exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,20 +19,20 @@ jobs:
     name: Lychee link check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # Excludes, retries and accepted status codes come from lychee.toml, which
       # `npm run links` uses too, so local and CI runs check the same things.
       - name: Run lychee
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --config lychee.toml './**/*.md'
           fail: false
 
       - name: Create issue on broken links (scheduled runs only)
         if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != '0'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         with:
           title: 'Link checker: broken links detected'
           content-filepath: ./lychee/out.md

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Validate workflow syntax
         run: |
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Detect project type
         id: detect
@@ -130,7 +130,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.detect.outputs.type == 'node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/*'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Semver tags only. The floating major pointer (v1) sits on the same commit
+      # as the release tag, and a bare 'v*' would fire this workflow for it too —
+      # where "Validate version format" rejects anything that is not vX.Y.Z, so
+      # every pointer move would leave a failed run behind.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Extract version
         id: version
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -142,7 +142,7 @@ jobs:
           cat release_notes.md
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: release-build-${{ needs.validate.outputs.version }}
           path: |
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: release-build-${{ needs.validate.outputs.version }}
           path: ./release/
@@ -206,10 +206,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: release-build-${{ needs.validate.outputs.version }}
           path: ./release/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,8 +5,6 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-  schedule:
-    - cron: '0 6 * * 1' # Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -71,13 +69,13 @@ jobs:
           retention-days: 30
 
   # Dev-dependency advisories are deliberately non-gating, which means nothing
-  # about them reaches a human on a normal PR. This weekly job is the mechanism
-  # that surfaces them: it opens (or refreshes) a single tracking issue so the
-  # backlog stays visible, and closes it once the tree is clean.
+  # about them reaches a human on a normal PR. This manually-triggered job is
+  # the mechanism that surfaces them: it opens (or refreshes) a single tracking
+  # issue so the backlog stays visible, and closes it once the tree is clean.
   audit-report:
     name: Report audit findings
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       issues: write
@@ -112,7 +110,7 @@ jobs:
               lines.push(\`| \${name} | \${v.severity} | \${fix} |\`);
             }
             const body = [
-              \`Weekly \\\`npm audit\\\` found **\${total}** advisories \` +
+              \`\\\`npm audit\\\` found **\${total}** advisories \` +
                 \`(\${m.critical} critical, \${m.high} high, \${m.moderate} moderate, \${m.low} low).\`,
               '',
               'This extension ships **zero production dependencies**, so these are',
@@ -265,11 +263,11 @@ jobs:
             .
         continue-on-error: true
 
-  # OWASP Dependency Check (comprehensive - weekly only)
+  # OWASP Dependency Check (comprehensive - manual runs only)
   owasp-dependency-check:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
 
@@ -329,7 +327,7 @@ jobs:
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,10 +22,10 @@ jobs:
     name: NPM Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -63,7 +63,7 @@ jobs:
         run: npm audit --json > npm-audit-results.json || true
 
       - name: Upload audit results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: npm-audit-results
@@ -82,10 +82,10 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -134,7 +134,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Open or update tracking issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         # Pass the count through the environment rather than interpolating
         # ${{ }} into the script body: expression interpolation is substituted
         # as raw text before the script is parsed, so it is the standard
@@ -195,7 +195,7 @@ jobs:
     name: Gitleaks (secrets)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -254,10 +254,10 @@ jobs:
     name: OSV-Scanner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run OSV-Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2.1.0
+        uses: google/osv-scanner-action/osv-scanner-action@b00f71e051ddddc6e46a193c31c8c0bf283bf9e6 # v2.1.0
         with:
           scan-args: |-
             --lockfile=package-lock.json
@@ -271,10 +271,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -283,7 +283,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: OWASP Dependency Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600 # 1.1.0
         with:
           project: ${{ github.repository }}
           path: '.'
@@ -313,14 +313,14 @@ jobs:
             --enableExperimental
 
       - name: Upload OWASP results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: owasp-dependency-check-report
           path: reports/
           retention-days: 90
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           sarif_file: reports/dependency-check-report.sarif
         if: always()
@@ -331,10 +331,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -356,7 +356,7 @@ jobs:
           license-checker --failOn 'GPL;AGPL;UNKNOWN' || echo "Review licenses above"
 
       - name: Upload license report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: license-report
           path: licenses.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -267,7 +267,10 @@ jobs:
   owasp-dependency-check:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    # CLAUDE.md requires OWASP Dependency-Check to run on pull_request: a
+    # dependency vulnerability enters the tree via a PR, so that is where it
+    # must be caught. Manual dispatch stays available for ad-hoc runs.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -280,35 +283,37 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # Pinned to a maintained `main` commit, NOT the 1.1.0 tag. 1.1.0
+      # (2021-04-28) declares only project/path/format/others — it has no
+      # `args` and no `out` — so against that tag every flag below was
+      # silently discarded: the scan ran with no --enableExperimental and,
+      # more importantly, no failure gate at all. Its image is the floating
+      # `owasp/dependency-check-action:latest` either way, so the SHA pins the
+      # wrapper, not the scanner.
       - name: OWASP Dependency Check
-        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600 # 1.1.0
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main @ 2025-12-10
         with:
           project: ${{ github.repository }}
           path: '.'
+          out: 'reports'
           # `--format` takes a single value, not a comma-separated list, and
           # the action offers no way to repeat it — 'HTML,JSON,SARIF' was
           # rejected outright. 'ALL' is the supported way to get more than one,
           # and it still writes dependency-check-report.sarif, which is the
           # path the SARIF upload step below reads.
           format: 'ALL'
-          # Only --enableExperimental is needed. The two flags that used to be
-          # here were both wrong:
+          # --nodeAuditAnalyzer and --nodePackageSkipDevDependencies false were
+          # both removed earlier and must not come back: the first does not
+          # exist (the Node Audit Analyzer is on unless --disableNodeAudit) and
+          # the second is a bare switch that *skips* dev dependencies — which
+          # would make this job scan nothing, since the extension ships zero
+          # production dependencies.
           #
-          #   --nodeAuditAnalyzer                  does not exist; it aborted
-          #                                        the whole scan. The Node
-          #                                        Audit Analyzer is on by
-          #                                        default (--disableNodeAudit
-          #                                        turns it off).
-          #   --nodePackageSkipDevDependencies     is a bare switch, so the
-          #     false                              trailing "false" was a stray
-          #                                        argument — and the switch
-          #                                        *skips* dev dependencies,
-          #                                        the opposite of the intent.
-          #
-          # Skipping dev dependencies would make this job scan nothing at all:
-          # the extension ships zero production dependencies.
+          # --failOnCVSS 7 is the gate. Without it the scanner exits 0 whatever
+          # it finds and this job is a report generator, not a check.
           args: >
             --enableExperimental
+            --failOnCVSS 7
 
       - name: Upload OWASP results
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -327,7 +332,9 @@ jobs:
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    # Content/compliance checks run on pull_request per CLAUDE.md; a
+    # non-allowlisted licence arrives with the PR that adds the dependency.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -366,3 +366,29 @@ jobs:
           name: license-report
           path: licenses.json
           retention-days: 90
+
+  # Reports action pins whose tag has moved since they were pinned.
+  #
+  # Pinning to a SHA closed a supply-chain hole and opened a maintenance job in
+  # exchange: a pinned SHA is immune to a hijacked tag and equally immune to the
+  # fixes that tag would have carried. Dependabot used to own refreshing them and
+  # is banned under the no-scheduled-Actions policy, so this is the mechanism.
+  #
+  # workflow_dispatch only, deliberately. It reports on the state of the world
+  # rather than on a change, so gating a PR with it would fail builds that
+  # introduced nothing — the drift arrives when upstream moves a tag. Run it when
+  # someone is ready to read release notes and act.
+  #
+  # Plain node, no npm ci and no NPM_TOKEN: the script uses only node builtins.
+  action-pins:
+    name: Action Pin Freshness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Check action pin freshness
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-action-pins.js

--- a/.npmrc
+++ b/.npmrc
@@ -14,4 +14,3 @@ cache-min=3600
 loglevel=error
 @afixt:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.7](https://github.com/AFixt/accessibility-highlighter/compare/v1.0.6...v1.0.7) (2026-08-20)
+
+### Bug Fixes
+
+- **ci:** make the owasp job real — off the 1.1.0 tag, gated, and on prs ([e60f0b4](https://github.com/AFixt/accessibility-highlighter/commit/e60f0b4bbf60c77c61dfaa175587d595873f1fdc))
+- **ci:** pin action refs in disabled workflow files too ([e6b9864](https://github.com/AFixt/accessibility-highlighter/commit/e6b986412105b93e6863d5a0474b3531e1c75ff0)), closes [AFixt/batch-scanner#44](https://github.com/AFixt/accessibility-highlighter/issues/44)
+- **ci:** pin workflow actions to commit SHAs ([6fc86c5](https://github.com/AFixt/accessibility-highlighter/commit/6fc86c58519cdb7a875c387d6eec750639d5bd47)), closes [AFixt/batch-scanner#44](https://github.com/AFixt/accessibility-highlighter/issues/44)
+- **ci:** remove all scheduled (cron) triggers from workflows ([b5645f1](https://github.com/AFixt/accessibility-highlighter/commit/b5645f1a6bf4909f397e7d78193b396c88059d97)), closes [#92](https://github.com/AFixt/accessibility-highlighter/issues/92)
+
+### Documentation
+
+- **ci:** correct the Dependabot alerts claim in the CI policy ([1f18dd3](https://github.com/AFixt/accessibility-highlighter/commit/1f18dd332795df533a804daffdd57a4149126b9d))
+- **claude:** document the release flow and the main back-merge ([923b283](https://github.com/AFixt/accessibility-highlighter/commit/923b28300022010acb41f997711f01783bb10f20))
+
 ### [1.0.6](https://github.com/AFixt/accessibility-highlighter/compare/v1.0.5...v1.0.6) (2026-08-01)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. See [standa
 - **ci:** pin action refs in disabled workflow files too ([e6b9864](https://github.com/AFixt/accessibility-highlighter/commit/e6b986412105b93e6863d5a0474b3531e1c75ff0)), closes [AFixt/batch-scanner#44](https://github.com/AFixt/accessibility-highlighter/issues/44)
 - **ci:** pin workflow actions to commit SHAs ([6fc86c5](https://github.com/AFixt/accessibility-highlighter/commit/6fc86c58519cdb7a875c387d6eec750639d5bd47)), closes [AFixt/batch-scanner#44](https://github.com/AFixt/accessibility-highlighter/issues/44)
 - **ci:** remove all scheduled (cron) triggers from workflows ([b5645f1](https://github.com/AFixt/accessibility-highlighter/commit/b5645f1a6bf4909f397e7d78193b396c88059d97)), closes [#92](https://github.com/AFixt/accessibility-highlighter/issues/92)
+- **ci:** trigger the release workflow on semver tags only ([afcb408](https://github.com/AFixt/accessibility-highlighter/commit/afcb408e938b4eeb18c0f4e3d4ddc7c5e3254211))
 
 ### Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ The Accessibility Highlighter is a Chrome extension that identifies accessibilit
 This project follows Git Flow branching strategy. All development work must adhere to the following:
 
 ### Branch Structure
+
 - **main**: Production-ready code only. Never commit directly to main.
 - **develop**: Integration branch for features. All feature branches merge here first.
 - **feature/**: Create feature branches from develop (e.g., feature/add-keyboard-nav)
@@ -18,6 +19,7 @@ This project follows Git Flow branching strategy. All development work must adhe
 - **hotfix/**: Emergency fixes from main that bypass develop
 
 ### Workflow Rules
+
 1. Always create feature branches from develop: `git checkout -b feature/feature-name develop`
 2. Merge feature branches back to develop via pull request
 3. Create release branches from develop when ready for production
@@ -25,10 +27,23 @@ This project follows Git Flow branching strategy. All development work must adhe
 5. Create hotfix branches from main for critical production issues
 6. Merge hotfix branches to both main and develop
 
+### Releases
+
+This project promotes `develop` to `main` directly via pull request; the `release/` branch step above is not used in practice — every tag from v1.0.3 onward sits on a `Merge pull request ... from AFixt/develop` commit.
+
+1. Bump on develop with standard-version (`npm run release:patch` / `:minor` / `:major`). It updates package.json, package-lock.json, manifest.json and CHANGELOG.md, and commits as `chore(release): vX.Y.Z`.
+2. Open a `develop` → `main` pull request titled `Release vX.Y.Z`; merge once checks pass.
+3. Tag the merge commit on main and push the tag:
+   `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
+   Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds the per-browser packages and creates the GitHub release from the matching CHANGELOG section.
+4. **Merge `main` back into `develop` and push.** This is the "and develop" half of workflow rule 4, and it is easy to lose because the release-branch step is skipped. Tags are created on main, so without it no tag is reachable from develop: `git describe` on develop goes stale and standard-version diffs against a long-superseded tag, producing a changelog that re-lists already-shipped work. (This was skipped from v1.0.2 until v1.0.6.) Expect an empty content diff — if real content appears, something reached main that develop never saw.
+
 ### Commit Messages
+
 - Use conventional commit format when applicable
 - Include ticket/issue numbers if available
 - Keep messages clear and descriptive
+- Subjects must be entirely lower-case (commitlint `subject-case`), so write `fix(docs): repoint the github links`, not `fix(docs): repoint the GitHub links`
 
 ## Project Todo List
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,43 @@ If this project installs any `@afixt/*` scoped packages, npm authentication is h
 - Installing `@afixt/*` scoped packages should **not** return `404`. A `404` here is an authentication/token problem, not a missing package.
 - If you do hit a `404`, remove any **repo-level** `NPM_TOKEN` secret — a repo-level token is likely stale and conflicts with the org-level secret.
 - Do not override `NPM_TOKEN` per repository; always rely on the org-level secret.
+
+## CI policy: no scheduled GitHub Actions
+
+**No GitHub Actions workflow in this repository may use a `schedule:` (cron)
+trigger, and no scheduled workflow that has been removed may be added back.**
+This is a standing constraint, not a default to be traded away for convenience.
+
+A timer-triggered check reports a problem hours or days after it entered the
+codebase, attributes it to no one, and gets ignored. The same check run against a
+pull request blocks the defect at the point of introduction.
+
+### Rules
+
+- No `on: schedule:` and no `- cron:` in any file under `.github/workflows/`.
+- No `.github/dependabot.yml` — Dependabot is a scheduled updater and is covered
+  by this policy. GitHub **security alerts** are event-driven notifications, not
+  scheduled jobs, and remain enabled.
+- Every check a scheduled job would have performed runs as a step in the
+  pull-request pipeline instead:
+  - Dependency vulnerability and freshness checks (`npm audit`, `npm outdated`,
+    OWASP Dependency-Check) run on `pull_request`.
+  - Static analysis (CodeQL and equivalents) runs on `pull_request`.
+  - Link checking, docs linting, and content checks run on `pull_request`,
+    path-filtered to the files that can break them.
+  - SBOM generation runs in the release/publish pipeline — an SBOM is a build
+    output, not a periodic report.
+  - DAST scans (ZAP and equivalents) run against the PR preview environment or
+    as a post-deploy gate, not against a static URL on a timer.
+  - End-to-end suites run as a smoke subset on `pull_request` and as the full
+    matrix on merge to the default branch — never nightly.
+- `workflow_dispatch` is allowed. A manual, on-demand run is not a scheduled run.
+- Event-driven triggers (`push`, `pull_request`, `release`, `repository_dispatch`,
+  `workflow_call`) are allowed and preferred.
+- Genuinely periodic *product* work — batch jobs, data pipelines, report
+  generation — does not belong in GitHub Actions at all. Run it on real
+  infrastructure with its own scheduler, alerting, and retries.
+
+### If you think you need an exception
+
+You do not add the cron. Raise it with the repository owner first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,12 @@ pull request blocks the defect at the point of introduction.
 ### Rules
 
 - No `on: schedule:` and no `- cron:` in any file under `.github/workflows/`.
-- No `.github/dependabot.yml` — Dependabot is a scheduled updater and is covered
-  by this policy. GitHub **security alerts** are event-driven notifications, not
-  scheduled jobs, and remain enabled.
+- No Dependabot, in any form. `.github/dependabot.yml` is a scheduled updater
+  and is covered by this policy. Dependabot **security alerts** and **automated
+  security fixes** are switched off at the repository level too — verified by
+  API on 2026-08-16. Nothing watches dependencies between pushes, so the
+  dependency checks in the pull-request pipeline are the only place a
+  vulnerable dependency gets caught.
 - Every check a scheduled job would have performed runs as a step in the
   pull-request pipeline instead:
   - Dependency vulnerability and freshness checks (`npm audit`, `npm outdated`,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Accessibility Highlighter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A browser extension to highlight accessibility problems on the page, giving a visual indication of what the problems are",
   "author": "AFixt",
   "permissions": ["storage", "activeTab"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1275,9 +1275,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5349,9 +5349,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5589,9 +5589,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5762,9 +5762,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6000,9 +6000,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8204,9 +8204,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9218,9 +9218,9 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11141,9 +11141,9 @@
       }
     },
     "node_modules/read-package-json/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/a11y-highlighter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/a11y-highlighter",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@afixt/a11y-highlighter",
   "version": "1.0.6",
+  "private": true,
   "description": "The Accessibility Highlighter finds accessibility problems on a website and highlights them on the page to give a visual indication of what the problems are. It also logs errors to console and annotates the DOM.",
   "main": "src/background.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/a11y-highlighter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "The Accessibility Highlighter finds accessibility problems on a website and highlights them on the page to give a visual indication of what the problems are. It also logs errors to console and annotates the DOM.",
   "main": "src/background.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@afixt/a11y-highlighter",
   "version": "1.0.6",
-  "private": true,
   "description": "The Accessibility Highlighter finds accessibility problems on a website and highlights them on the page to give a visual indication of what the problems are. It also logs errors to console and annotates the DOM.",
   "main": "src/background.js",
   "scripts": {
@@ -59,6 +58,9 @@
     "url": "https://github.com/AFixt/accessibility-highlighter"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",

--- a/scripts/action-pins.js
+++ b/scripts/action-pins.js
@@ -1,0 +1,211 @@
+/**
+ * Parses and classifies the pinned GitHub Actions references in
+ * .github/workflows. Pure logic only — no I/O — so it is unit-testable
+ * (tests/unit/action-pins.test.js). The CLI wrapper that resolves tags against
+ * the GitHub API is scripts/check-action-pins.js.
+ *
+ * Why this exists: every action reference here is pinned to a commit SHA so a
+ * tag cannot be silently repointed under us. That closed a real supply-chain
+ * hole and created an unowned maintenance job in exchange — a pinned SHA is
+ * immune to a hijacked tag, and equally immune to the security fixes that tag
+ * would have carried. Dependabot used to own refreshing the pins; it is now
+ * banned repo-wide along with every other scheduled automation (#45),
+ * so this check is the mechanism instead of it.
+ *
+ * The comparison is between the pinned SHA and the tag recorded in the
+ * trailing comment (`@<sha> # v4.4.0`). Actions publish fixes by moving their
+ * floating tag, so "the tag now points somewhere else" is exactly the signal
+ * worth having.
+ *
+ * Known limitation: this cannot see a new major. A repository pinned to v4
+ * keeps resolving v4 even after upstream ships v5. Dependabot would have
+ * caught that; a human reading release notes still has to.
+ *
+ * Ported from lexic-a11y's scripts/action-pins.mjs (itself from a11y-mcp's
+ * mcp-server/scripts/actionPins.ts). Rewritten as CommonJS to match this
+ * repository's scripts/ idiom — see scripts/check-sarif.js. The parsing and
+ * classification logic is unchanged, so a fix in any of the three ports
+ * applies to the others.
+ */
+
+/**
+ * @typedef {object} ActionPin
+ * @property {string} file Workflow file the reference was found in.
+ * @property {number} line 1-based line number, so output pastes into an editor.
+ * @property {string} owner GitHub owner of the action.
+ * @property {string} repo Repository name of the action.
+ * @property {string} [sha] The 40-char commit SHA the workflow pins, if pinned.
+ * @property {string} [tag] The version recorded in the trailing comment.
+ * @property {string} ref The raw ref after `@`, whether or not it is a SHA.
+ */
+
+/**
+ * @typedef {(
+ *   | {kind: 'current'}
+ *   | {kind: 'stale', expected: string}
+ *   | {kind: 'unknown', reason: string}
+ * )} PinStatus
+ * current: pinned SHA matches what the tag resolves to today.
+ * stale: the tag has moved since this was pinned.
+ * unknown: nothing to compare against — no SHA, no tag comment, or the tag
+ * could not be resolved.
+ */
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * Split a `uses:` line into its reference and any trailing `# tag` comment.
+ *
+ * String operations rather than a regex, for the same reason as
+ * `splitActionRef` below: every pattern that expressed this concisely was
+ * rejected by `security/detect-unsafe-regex` under this repository's lint
+ * config. Scanning for the delimiters directly is linear by construction, so
+ * there is nothing to be conservative about.
+ *
+ * @param {string} rawLine One line of a workflow file.
+ * @returns {{value: string, tag?: string} | undefined} The reference and its tag comment, when the line is a `uses:`.
+ */
+function splitUsesLine(rawLine) {
+  let rest = rawLine.trim();
+  if (rest.startsWith('- ')) {
+    rest = rest.slice(2).trim();
+  }
+  if (!rest.startsWith('uses:')) {
+    return undefined;
+  }
+
+  rest = rest.slice('uses:'.length).trim();
+  if (rest === '') {
+    return undefined;
+  }
+
+  const hash = rest.indexOf('#');
+  const value = (hash === -1 ? rest : rest.slice(0, hash)).trim();
+  const comment = hash === -1 ? '' : rest.slice(hash + 1).trim();
+  if (value === '') {
+    return undefined;
+  }
+
+  // Only the first word of the comment is the tag; anything after it is prose.
+  const [tag] = comment.split(/\s/, 1);
+  return tag ? { value, tag } : { value };
+}
+
+/**
+ * Split `owner/repo[/subpath]@ref` into its parts.
+ *
+ * Done with string operations rather than one regex on purpose. The upstream
+ * ports match the whole thing in a single pattern whose optional `/subpath`
+ * group overlaps the preceding `owner/repo`, which is ambiguous enough that
+ * `security/detect-unsafe-regex` and `sonarjs/regex-complexity` both reject it
+ * under this repository's lint config. Splitting on the last `@` and then on
+ * `/` is unambiguous, linear, and easier to read than the pattern it replaces.
+ *
+ * Local (`./.github/actions/x`) and Docker (`docker://…`) references have no
+ * upstream tag to compare against, so they are skipped here.
+ *
+ * @param {string} value The raw value following `uses:`.
+ * @returns {{owner: string, repo: string, ref: string} | undefined} The parts, when it is an upstream action reference.
+ */
+function splitActionRef(value) {
+  if (value.startsWith('./') || value.startsWith('docker://')) {
+    return undefined;
+  }
+
+  const at = value.lastIndexOf('@');
+  if (at <= 0 || at === value.length - 1) {
+    return undefined;
+  }
+
+  const [owner, repo] = value.slice(0, at).split('/');
+  if (!owner || !repo) {
+    return undefined;
+  }
+
+  return { owner, repo, ref: value.slice(at + 1) };
+}
+
+/**
+ * Pull every action reference out of one workflow file's text.
+ *
+ * @param {string} text The workflow file contents.
+ * @param {string} file The file name, recorded on each pin for reporting.
+ * @returns {ActionPin[]} Every `uses:` reference found.
+ */
+function parseActionPins(text, file) {
+  const pins = [];
+
+  text.split('\n').forEach((rawLine, index) => {
+    const line = splitUsesLine(rawLine);
+    if (!line) {
+      return;
+    }
+
+    const parts = splitActionRef(line.value);
+    if (!parts) {
+      return;
+    }
+
+    const { owner, repo, ref } = parts;
+    const { tag } = line;
+
+    pins.push({
+      file,
+      line: index + 1,
+      owner,
+      repo,
+      ref,
+      // A tag comment on an unpinned ref is noise; only record it with a SHA.
+      ...(SHA_PATTERN.test(ref) ? { sha: ref } : {}),
+      ...(tag ? { tag } : {})
+    });
+  });
+
+  return pins;
+}
+
+/**
+ * Compare one pin against the SHA its tag resolves to upstream.
+ *
+ * `resolvedSha` is undefined when the tag could not be resolved — a deleted
+ * tag, a branch name in the comment, or a rate-limited API call. That is
+ * reported as unknown rather than stale, because "we could not check" and
+ * "this is out of date" warrant different responses.
+ *
+ * @param {ActionPin} pin The parsed reference.
+ * @param {string | undefined} resolvedSha What the tag points at today.
+ * @returns {PinStatus} How the pin compares.
+ */
+function classifyPin(pin, resolvedSha) {
+  if (!pin.sha) {
+    return {
+      kind: 'unknown',
+      reason: `not pinned to a SHA (points at "${pin.ref}")`
+    };
+  }
+
+  if (!pin.tag) {
+    return {
+      kind: 'unknown',
+      reason: 'pinned to a SHA but has no "# <tag>" comment to check it against'
+    };
+  }
+
+  if (!resolvedSha) {
+    return { kind: 'unknown', reason: `tag "${pin.tag}" could not be resolved upstream` };
+  }
+
+  return resolvedSha === pin.sha ? { kind: 'current' } : { kind: 'stale', expected: resolvedSha };
+}
+
+/**
+ * `owner/repo` — the key a tag is resolved against.
+ *
+ * @param {ActionPin} pin The parsed reference.
+ * @returns {string} The repository slug.
+ */
+function repoSlug(pin) {
+  return `${pin.owner}/${pin.repo}`;
+}
+
+module.exports = { parseActionPins, classifyPin, repoSlug };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const EXTENSION_DIR = path.join(ROOT_DIR, 'src');
@@ -82,10 +82,21 @@ function createZip(sourceDir, outputPath) {
     fs.unlinkSync(outputPath);
   }
 
-  // Create zip (exclude .DS_Store files)
-  execSync(`cd "${sourceDir}" && zip -r "${outputPath}" . -x "*.DS_Store"`, {
+  // Create zip (exclude .DS_Store files).
+  // spawnSync with an argument array runs zip directly (no shell), so
+  // sourceDir/outputPath cannot inject shell commands. Unlike execSync,
+  // spawnSync does not throw on failure — check the result so a missing or
+  // failing zip aborts the build instead of silently producing no archive.
+  const result = spawnSync('zip', ['-r', outputPath, '.', '-x', '*.DS_Store'], {
+    cwd: sourceDir,
     stdio: 'inherit'
   });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`zip exited with status ${result.status} while creating ${outputPath}`);
+  }
 }
 
 /**

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Reports GitHub Actions SHA pins that have drifted from the tag they claim.
+ *
+ * Dependabot used to own refreshing these pins; scheduled automation
+ * (Dependabot included) is banned repo-wide (#45), so this check is the
+ * mechanism instead. Run it via the `Action Pin Freshness` workflow_dispatch
+ * job in security.yml, or locally:
+ *
+ *   npm run security:action-pins
+ *
+ * Exit code 1 when any pin is stale — the tag has moved since it was pinned,
+ * which usually means upstream shipped a fix this repository is frozen
+ * against. References that cannot be checked (no SHA, no tag comment, or a
+ * branch pin like Dependency-Check_Action's deliberate `main` pin) are
+ * reported as unknown and do not fail the run: "we could not check" and
+ * "this is out of date" warrant different responses.
+ *
+ * Env vars:
+ *   GITHUB_TOKEN — raises the API rate limit from 60/hr to 5000/hr. Optional
+ *                  locally; supplied automatically in Actions.
+ */
+const fs = require('node:fs/promises');
+const { join } = require('node:path');
+
+const { classifyPin, parseActionPins, repoSlug } = require('./action-pins');
+
+const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
+
+const API = 'https://api.github.com';
+
+/**
+ * Request headers for the GitHub REST API.
+ *
+ * @returns {Record<string, string>} Headers, with auth when available.
+ */
+function headers() {
+  const token = process.env.GITHUB_TOKEN;
+  return {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(token ? { Authorization: `Bearer ${token}` } : {})
+  };
+}
+
+/**
+ * Resolve `owner/repo` + tag to the commit SHA it points at today.
+ *
+ * Annotated tags resolve to a tag object rather than a commit, so those need
+ * a second hop to get the commit a workflow would actually check out. Returns
+ * undefined for anything unresolvable; the caller reports that as unknown
+ * rather than treating it as drift.
+ *
+ * @param {string} slug `owner/repo`.
+ * @param {string} tag The tag name from the pin's trailing comment.
+ * @returns {Promise<string | undefined>} The commit SHA, if resolvable.
+ */
+async function resolveTag(slug, tag) {
+  const res = await fetch(`${API}/repos/${slug}/git/ref/tags/${encodeURIComponent(tag)}`, {
+    headers: headers()
+  });
+  if (!res.ok) {
+    return undefined;
+  }
+
+  const ref = await res.json();
+  if (!ref.object?.sha) {
+    return undefined;
+  }
+  if (ref.object.type !== 'tag') {
+    return ref.object.sha;
+  }
+
+  const deref = await fetch(`${API}/repos/${slug}/git/tags/${ref.object.sha}`, {
+    headers: headers()
+  });
+  if (!deref.ok) {
+    return undefined;
+  }
+
+  const annotated = await deref.json();
+  return annotated.object?.sha;
+}
+
+/*
+ * The fs calls below take a directory supplied on the command line, which is
+ * the entire job of a CLI that reads a workflows directory. The value comes
+ * from the workflow step that invokes this script, not from anything the
+ * analysed code can influence, and the script only ever reads.
+ */
+
+/**
+ * Parse every workflow file in a directory into action pins.
+ *
+ * @param {string} dir The workflows directory.
+ * @returns {Promise<import('./action-pins').ActionPin[]>} All references.
+ */
+async function collectPins(dir) {
+  const entries = await fs.readdir(dir);
+  const pins = [];
+
+  for (const name of entries.filter(n => n.endsWith('.yml') || n.endsWith('.yaml')).sort()) {
+    pins.push(...parseActionPins(await fs.readFile(join(dir, name), 'utf8'), name));
+  }
+
+  return pins;
+}
+
+/**
+ * Classify every pin, printing one line each, and bucket the ones that need
+ * attention. Split out of main() to keep that function within this
+ * repository's complexity limits.
+ *
+ * @param {import('./action-pins').ActionPin[]} pins Parsed references.
+ * @param {Map<string, string | undefined>} resolved Tag lookups, keyed `slug@tag`.
+ * @returns {{stale: string[], unknown: string[]}} Reportable lines per bucket.
+ */
+function report(pins, resolved) {
+  const stale = [];
+  const unknown = [];
+
+  for (const pin of pins) {
+    const status = classifyPin(pin, resolved.get(`${repoSlug(pin)}@${pin.tag}`));
+    const where = `${pin.file}:${pin.line}`;
+
+    if (status.kind === 'current') {
+      console.log(`  ok       ${where}  ${repoSlug(pin)}@${pin.tag}`);
+    } else if (status.kind === 'stale') {
+      stale.push(`${where}  ${repoSlug(pin)}  ${pin.tag}: ${pin.sha} -> ${status.expected}`);
+      console.log(`  STALE    ${where}  ${repoSlug(pin)}@${pin.tag}`);
+    } else {
+      unknown.push(`${where}  ${repoSlug(pin)}  ${status.reason}`);
+      console.log(`  unknown  ${where}  ${repoSlug(pin)}  ${status.reason}`);
+    }
+  }
+
+  return { stale, unknown };
+}
+
+/**
+ * Check every pin and report; exit 1 if any is stale.
+ *
+ * @returns {Promise<void>} Resolves when the report is printed.
+ */
+async function main() {
+  const dir = process.argv[2] || DEFAULT_WORKFLOW_DIR;
+  const pins = await collectPins(dir);
+
+  if (pins.length === 0) {
+    console.error(`No action references found in ${dir}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // One lookup per distinct repo+tag: the references collapse to a handful,
+  // which matters against an unauthenticated 60/hr rate limit.
+  const wanted = new Map();
+  for (const pin of pins) {
+    if (pin.sha && pin.tag) {
+      wanted.set(`${repoSlug(pin)}@${pin.tag}`, { slug: repoSlug(pin), tag: pin.tag });
+    }
+  }
+
+  const resolved = new Map();
+  await Promise.all(
+    [...wanted].map(async ([key, { slug, tag }]) => resolved.set(key, await resolveTag(slug, tag)))
+  );
+
+  const { stale, unknown } = report(pins, resolved);
+
+  console.log(
+    `\n${pins.length} references checked: ${pins.length - stale.length - unknown.length} current, ` +
+      `${stale.length} stale, ${unknown.length} unknown.`
+  );
+
+  if (unknown.length > 0) {
+    console.log('\nCould not be checked:');
+    for (const line of unknown) {
+      console.log(`  ${line}`);
+    }
+  }
+
+  if (stale.length > 0) {
+    console.log('\nStale pins — the tag has moved since these were pinned:');
+    for (const line of stale) {
+      console.log(`  ${line}`);
+    }
+    console.log(
+      '\nUpdate the SHA in the workflow, keeping the "# <tag>" comment accurate.\n' +
+        'Read the upstream release notes first — that is the review step a pinned\n' +
+        'SHA buys you, and the reason this repository pins rather than floating.'
+    );
+    process.exitCode = 1;
+  }
+}
+
+// Failures set process.exitCode rather than calling process.exit(), so the
+// script still exits non-zero for CI without truncating pending stdout.
+main().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Patch release. No `feat` commits and no breaking changes since v1.0.6 — this is CI hardening, security/dependency chores, and documentation. No user-facing extension behavior changes.

## What's shipping

- **Supply-chain hardening** — workflow actions pinned to commit SHAs, including the disabled workflow files (#93)
- **No scheduled Actions** — every `cron` trigger removed and the policy written into CLAUDE.md; the OWASP job made real, gated, and PR-triggered (#94)
- **build.js hardening** — `child_process` call sanitized (#95)
- **npm audit** — dev-dependency advisories resolved (#93)
- **Action Pin Freshness check** — `workflow_dispatch` job reporting pins whose upstream tag has moved, replacing the banned Dependabot updater (#97)
- **npm publish config** — deprecated `always-auth` removed; visibility made explicit as public via `publishConfig.access` (#98)
- **Docs** — release flow and the main→develop back-merge documented; Dependabot alerts claim corrected (#96)

## Release hygiene

The v1.0.6 back-merge had been skipped, leaving `v1.0.6` unreachable from develop. Repaired in #99 before cutting this release, so the generated changelog covers only v1.0.6...v1.0.7 rather than re-listing shipped work.

https://github.com/AFixt/accessibility-highlighter/compare/v1.0.6...develop