### PR TITLE
fix(ci): trigger the release workflow on semver tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Semver tags only. The floating major pointer (v1) sits on the same commit
+      # as the release tag, and a bare 'v*' would fire this workflow for it too —
+      # where "Validate version format" rejects anything that is not vX.Y.Z, so
+      # every pointer move would leave a failed run behind.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Prerequisite for maintaining a floating `v1` major-version pointer.

`.github/workflows/release.yml` triggers on `v*`, and its first job rejects anything that is not `vX.Y.Z`:

```
if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
  echo "Error: Version must be in format v1.2.3"
  exit 1
fi
```

The pointer is force-moved onto the release commit on every release, so with the old filter each move fired this workflow and failed the validate job — a red run per release, caused by nothing but the pointer.

Narrowing the filter to `v[0-9]*.[0-9]*.[0-9]*` leaves real releases triggering exactly as before. Verified with actionlint locally.