### PR TITLE
fix(ci): fail the pin check when nothing resolved

### DIFF
--- a/scripts/action-pins.js
+++ b/scripts/action-pins.js
@@ -199,6 +199,31 @@ function classifyPin(pin, resolvedSha) {
 }
 
 /**
+ * Did the run resolve nothing at all?
+ *
+ * Every unresolved tag is reported as unknown, and unknown is not a failure —
+ * one dead tag among many should not fail the job. But if *nothing* resolved,
+ * the run has checked nothing, and reporting "0 stale" would be an all-clear
+ * the check never earned. That is an expired or missing token, a rate limit,
+ * or no network, and it is worth failing over.
+ *
+ * Only pins with both a SHA and a tag are checkable, so a repository with no
+ * checkable pins is not an outage — there was nothing to resolve.
+ *
+ * @param {ActionPin[]} pins Every parsed reference.
+ * @param {Map<string, string | undefined>} resolved Tag lookups, keyed `slug@tag`.
+ * @returns {boolean} True when there was something to check and none of it resolved.
+ */
+function checkedNothing(pins, resolved) {
+  const checkable = pins.filter(pin => pin.sha && pin.tag);
+  if (checkable.length === 0) {
+    return false;
+  }
+
+  return checkable.every(pin => !resolved.get(`${repoSlug(pin)}@${pin.tag}`));
+}
+
+/**
  * `owner/repo` — the key a tag is resolved against.
  *
  * @param {ActionPin} pin The parsed reference.
@@ -208,4 +233,4 @@ function repoSlug(pin) {
   return `${pin.owner}/${pin.repo}`;
 }
 
-module.exports = { parseActionPins, classifyPin, repoSlug };
+module.exports = { parseActionPins, classifyPin, checkedNothing, repoSlug };

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -21,8 +21,11 @@
  * reporting "0 stale" from that is an all-clear it never earned.
  *
  * Env vars:
- *   GITHUB_TOKEN — raises the API rate limit from 60/hr to 5000/hr. Optional
- *                  locally; supplied automatically in Actions.
+ *   GITHUB_TOKEN   — raises the API rate limit from 60/hr to 5000/hr. Optional
+ *                    locally; supplied automatically in Actions.
+ *   GITHUB_API_URL — API base, defaulting to https://api.github.com. Actions
+ *                    sets it on every run; it differs on GitHub Enterprise
+ *                    Server.
  */
 const fs = require('node:fs/promises');
 const { join } = require('node:path');
@@ -31,7 +34,10 @@ const { checkedNothing, classifyPin, parseActionPins, repoSlug } = require('./ac
 
 const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
 
-const API = 'https://api.github.com';
+// Actions sets GITHUB_API_URL on every run, and it is not api.github.com on
+// GitHub Enterprise Server. Honouring it is more correct than hardcoding, and
+// it gives the tests somewhere unreachable to point at.
+const API = (process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/+$/, '');
 
 /**
  * Request headers for the GitHub REST API.
@@ -48,42 +54,50 @@ function headers() {
 }
 
 /**
+ * GET a URL and parse it as JSON, or undefined if anything goes wrong.
+ *
+ * Network and DNS failures make fetch *throw* rather than return a bad
+ * response. Left uncaught, one unreachable host would reject the Promise.all
+ * over every lookup and unwind the whole run with a stack trace — skipping the
+ * checkedNothing guard whose message names "no network" as a case it handles.
+ * Collapsing both failure shapes to undefined makes that true, and keeps one
+ * transient blip among fifty lookups from taking down the report.
+ *
+ * @param {string} url The API URL to fetch.
+ * @returns {Promise<object | undefined>} The parsed body, if the call succeeded.
+ */
+async function getJson(url) {
+  try {
+    const res = await fetch(url, { headers: headers() });
+    return res.ok ? await res.json() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Resolve `owner/repo` + tag to the commit SHA it points at today.
  *
  * Annotated tags resolve to a tag object rather than a commit, so those need
  * a second hop to get the commit a workflow would actually check out. Returns
- * undefined for anything unresolvable; the caller reports that as unknown
- * rather than treating it as drift.
+ * undefined for anything unresolvable — including an unreachable API — and the
+ * caller reports that as unknown rather than treating it as drift.
  *
  * @param {string} slug `owner/repo`.
  * @param {string} tag The tag name from the pin's trailing comment.
  * @returns {Promise<string | undefined>} The commit SHA, if resolvable.
  */
 async function resolveTag(slug, tag) {
-  const res = await fetch(`${API}/repos/${slug}/git/ref/tags/${encodeURIComponent(tag)}`, {
-    headers: headers()
-  });
-  if (!res.ok) {
-    return undefined;
-  }
-
-  const ref = await res.json();
-  if (!ref.object?.sha) {
+  const ref = await getJson(`${API}/repos/${slug}/git/ref/tags/${encodeURIComponent(tag)}`);
+  if (!ref?.object?.sha) {
     return undefined;
   }
   if (ref.object.type !== 'tag') {
     return ref.object.sha;
   }
 
-  const deref = await fetch(`${API}/repos/${slug}/git/tags/${ref.object.sha}`, {
-    headers: headers()
-  });
-  if (!deref.ok) {
-    return undefined;
-  }
-
-  const annotated = await deref.json();
-  return annotated.object?.sha;
+  const annotated = await getJson(`${API}/repos/${slug}/git/tags/${ref.object.sha}`);
+  return annotated?.object?.sha;
 }
 
 /*

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -16,6 +16,10 @@
  * reported as unknown and do not fail the run: "we could not check" and
  * "this is out of date" warrant different responses.
  *
+ * Also exit code 1 when *nothing* resolved. One dead tag among many is not an
+ * outage, but zero successful lookups means the run checked nothing, and
+ * reporting "0 stale" from that is an all-clear it never earned.
+ *
  * Env vars:
  *   GITHUB_TOKEN — raises the API rate limit from 60/hr to 5000/hr. Optional
  *                  locally; supplied automatically in Actions.
@@ -23,7 +27,7 @@
 const fs = require('node:fs/promises');
 const { join } = require('node:path');
 
-const { classifyPin, parseActionPins, repoSlug } = require('./action-pins');
+const { checkedNothing, classifyPin, parseActionPins, repoSlug } = require('./action-pins');
 
 const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
 
@@ -178,6 +182,16 @@ async function main() {
     for (const line of unknown) {
       console.log(`  ${line}`);
     }
+  }
+
+  if (checkedNothing(pins, resolved)) {
+    console.error(
+      '\nNot one tag resolved, so nothing here was actually checked. That is an\n' +
+        'expired or missing GITHUB_TOKEN, an API rate limit, or no network — not a\n' +
+        'clean bill of health. Failing rather than reporting an all-clear.'
+    );
+    process.exitCode = 1;
+    return;
   }
 
   if (stale.length > 0) {

--- a/tests/action-pins.test.js
+++ b/tests/action-pins.test.js
@@ -13,7 +13,12 @@
  * "could not be checked" — a distinction classifyPin exists to make.
  */
 
-const { parseActionPins, classifyPin, repoSlug } = require('../scripts/action-pins');
+const {
+  parseActionPins,
+  classifyPin,
+  checkedNothing,
+  repoSlug
+} = require('../scripts/action-pins');
 
 const SHA = 'd23441a48e516b6c34aea4fa41551a30e30af803';
 const OTHER_SHA = '249970729cb0ef3589644e2896645e5dc5ba9c38';
@@ -211,6 +216,54 @@ describe('classifyPin', () => {
       expect(status.kind).toBe('unknown');
       expect(status.reason).toContain('v6');
     });
+  });
+});
+
+describe('checkedNothing', () => {
+  const checkable = [
+    { file: 'ci.yml', line: 1, owner: 'actions', repo: 'checkout', ref: SHA, sha: SHA, tag: 'v6' },
+    { file: 'ci.yml', line: 2, owner: 'actions', repo: 'setup-node', ref: SHA, sha: SHA, tag: 'v6' }
+  ];
+
+  it('is true when not one checkable pin resolved — a token, rate-limit or network failure', () => {
+    expect(checkedNothing(checkable, new Map())).toBe(true);
+  });
+
+  it('is false as soon as one resolves, so a single dead tag is not an outage', () => {
+    expect(checkedNothing(checkable, new Map([['actions/checkout@v6', SHA]]))).toBe(false);
+  });
+
+  it('is false when every pin resolved', () => {
+    const resolved = new Map([
+      ['actions/checkout@v6', SHA],
+      ['actions/setup-node@v6', SHA]
+    ]);
+
+    expect(checkedNothing(checkable, resolved)).toBe(false);
+  });
+
+  it('is false when nothing was checkable in the first place', () => {
+    // Nothing to resolve is not the same as failing to resolve: a repository
+    // with no SHA-pinned references has not suffered an outage.
+    const unpinned = [{ file: 'a.yml', line: 1, owner: 'some', repo: 'action', ref: 'main' }];
+
+    expect(checkedNothing(unpinned, new Map())).toBe(false);
+  });
+
+  it('ignores unpinned references when deciding, rather than counting them as failures', () => {
+    // A pin with no tag comment is unresolvable by construction. If it counted
+    // toward "checkable", one such reference alongside a healthy resolved pin
+    // could never reach the all-resolved state.
+    const mixed = [
+      ...checkable,
+      { file: 'a.yml', line: 3, owner: 'o', repo: 'r', ref: SHA, sha: SHA }
+    ];
+    const resolved = new Map([
+      ['actions/checkout@v6', SHA],
+      ['actions/setup-node@v6', SHA]
+    ]);
+
+    expect(checkedNothing(mixed, resolved)).toBe(false);
   });
 });
 

--- a/tests/check-action-pins.test.js
+++ b/tests/check-action-pins.test.js
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview Tests for scripts/check-action-pins.js
+ *
+ * tests/action-pins.test.js covers the parsing and classification the CLI is
+ * built from, including checkedNothing. What it cannot cover is whether the
+ * CLI still *calls* any of it: deleting the whole checkedNothing block from
+ * main() left every one of those tests green, which is the same silent pass
+ * the guard exists to prevent, one level up.
+ *
+ * So these run the real script as a subprocess and assert on its exit code,
+ * with GITHUB_API_URL pointed at a local server standing in for the API. A
+ * server answering 403 reproduces a rate limit, which is the likeliest way
+ * this check goes blind in practice.
+ *
+ * The one case that completes an HTTP request needs a raised timeout. The CLI
+ * finishes its work in well under a second and then sits at 0% CPU for
+ * anywhere from 3 to 15 seconds before the process exits — reproducible here
+ * down to a one-line script that does nothing but fetch, so it is not
+ * something this repository's code is doing, and not something a stub that
+ * closes its connections avoids. It costs the real workflow_dispatch run about
+ * 25 seconds of idle runner time too. Worth its own investigation; the timeout
+ * keeps this suite deterministic until then rather than leaving it to race
+ * Jest's 5s default.
+ */
+
+const { execFile } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+const SCRIPT = path.resolve(__dirname, '../scripts/check-action-pins.js');
+
+const SHA = 'd23441a48e516b6c34aea4fa41551a30e30af803';
+
+let tmpDir;
+let server;
+let apiUrl;
+let requestCount;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-action-pins-'));
+
+  // 403 is what a rate limit looks like, and resolveTag turns it into
+  // undefined exactly as it would against the real API.
+  server = http.createServer((req, res) => {
+    requestCount += 1;
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'API rate limit exceeded' }));
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  apiUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  requestCount = 0;
+});
+
+/**
+ * Write a workflows directory containing one file.
+ *
+ * @param {string} name Directory name, unique per case.
+ * @param {string[]} lines Contents of the workflow file.
+ * @returns {string} Path to the workflows directory.
+ */
+function workflowsDir(name, lines) {
+  const dir = path.join(tmpDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'ci.yml'), lines.join('\n'));
+  return dir;
+}
+
+/**
+ * Run the check against a workflows directory, with the stub API standing in
+ * for github.com.
+ *
+ * @param {string} dir The workflows directory to check.
+ * @param {string} [api] API base to use, defaulting to the stub server.
+ * @returns {Promise<{status: number, output: string}>} Exit code and combined output.
+ */
+async function check(dir, api = apiUrl) {
+  const options = {
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_API_URL: api, GITHUB_TOKEN: '' }
+  };
+
+  try {
+    const { stdout, stderr } = await execFileAsync('node', [SCRIPT, dir], options);
+    return { status: 0, output: `${stdout}${stderr}` };
+  } catch (error) {
+    return { status: error.code, output: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+  }
+}
+
+describe('check-action-pins CLI', () => {
+  it('fails when not one tag resolved, rather than reporting an all-clear', async () => {
+    const dir = workflowsDir('all-fail', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: actions/checkout@${SHA} # v6`
+    ]);
+
+    const { status, output } = await check(dir);
+
+    expect(requestCount).toBeGreaterThan(0); // it really did try
+    expect(output).toContain('nothing here was actually checked');
+    expect(status).toBe(1);
+  }, 30000);
+
+  it('treats an unusable API as a failed lookup rather than crashing', async () => {
+    // fetch throws on this rather than returning a bad response, which is the
+    // shape a DNS or network failure takes. Uncaught it would reject the
+    // Promise.all over every lookup and unwind past the guard with a stack
+    // trace; getJson's catch is what routes it back to "nothing resolved".
+    const dir = workflowsDir('unusable-api', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: actions/checkout@${SHA} # v6`
+    ]);
+
+    const { status, output } = await check(dir, 'http://127.0.0.1:0');
+
+    expect(output).toContain('nothing here was actually checked');
+    expect(output).not.toContain('TypeError');
+    expect(status).toBe(1);
+  }, 30000);
+
+  it('does not treat "nothing was checkable" as an outage', async () => {
+    // Floating refs carry no SHA, so there was never anything to resolve.
+    // Reporting them as unknown is right; failing the run over it is not.
+    const dir = workflowsDir('nothing-checkable', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      '      - uses: actions/checkout@v4'
+    ]);
+
+    const { status, output } = await check(dir);
+
+    expect(requestCount).toBe(0); // nothing was checkable, so nothing was looked up
+    expect(output).not.toContain('nothing here was actually checked');
+    expect(status).toBe(0);
+  });
+
+  it('fails when the directory holds no action references at all', async () => {
+    const dir = workflowsDir('empty', ['jobs:', '  a:', '    steps:', '      - run: echo hi']);
+
+    const { status, output } = await check(dir);
+
+    expect(output).toContain('No action references found');
+    expect(status).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes the Major found while reviewing #105.

## The defect

Every unresolved tag is reported as `unknown`, and `unknown` deliberately does not fail the run — one dead tag among many should not fail the job. But when **nothing** resolves, that same logic printed `0 stale` and exited 0.

Probed against this repository's real workflows with every lookup failing:

```
51 references checked: 0 current, 0 stale, 51 unknown.
main() would set exitCode? NO -> exits 0, job is GREEN
```

An expired or missing `GITHUB_TOKEN`, a 403 rate limit, or no network all produce exactly that — and the Action Pin Freshness job would have gone green through all three, reporting a clean bill of health for a run that verified nothing. Worse than no check, because it also stops anyone else from looking.

## The fix

Adds `checkedNothing`, which the sibling port in `a11y-assert/scripts/action-pins.mjs` already has and which this port was ported without — despite the docblock's claim that "a fix in any of the three ports applies to the others." The CLI now fails with:

> Not one tag resolved, so nothing here was actually checked. That is an expired or missing GITHUB_TOKEN, an API rate limit, or no network — not a clean bill of health. Failing rather than reporting an all-clear.

Wired at the same point in `main()` as the sibling, and the file docblock updated — it previously stated that unknowns never fail the run, which is no longer the whole truth.

A repository with no checkable pins returns `false`: nothing to resolve is not the same as failing to resolve.

## Verification

- **5 unit tests**, and all four mutations of the new function are caught (`every`→`some`, inverted lookup, dropped checkable filter, no-checkable→true)
- Coverage of `scripts/action-pins.js` stays at **100%** on all four axes; suite is 32 tests
- **End to end:** a real run still exits 1 on genuine drift, so the guard stays out of the way when lookups work — see below

## It found real drift

Running the check against this repository right now:

```
51 references checked: 49 current, 1 stale, 1 unknown.

Stale pins — the tag has moved since these were pinned:
  security.yml:326  github/codeql-action  v4: 5595ccaf... -> ff2f1c62...
```

**Not fixed here.** Updating that pin means reading upstream release notes first — that is the review step a pinned SHA buys you, and it belongs in its own PR.

## Known limitation

The guard *function* is unit-tested; its *wiring* in `check-action-pins.js` is verified only by the manual probe above. That CLI has no tests at all — it calls `api.github.com` with no injection point — so testing `main()` would need a refactor beyond this change.