### PR TITLE
chore: stop ignoring claude.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.zip
 *.log
 .DS_Store
-CLAUDE.md
 .claude
 
 # Artifacts written into the repo root by CI steps (ci.yml, security.yml).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ pull request blocks the defect at the point of introduction.
 - `workflow_dispatch` is allowed. A manual, on-demand run is not a scheduled run.
 - Event-driven triggers (`push`, `pull_request`, `release`, `repository_dispatch`,
   `workflow_call`) are allowed and preferred.
-- Genuinely periodic *product* work — batch jobs, data pipelines, report
+- Genuinely periodic _product_ work — batch jobs, data pipelines, report
   generation — does not belong in GitHub Actions at all. Run it on real
   infrastructure with its own scheduler, alerting, and retries.
 


### PR DESCRIPTION
## What

Removes the stale `CLAUDE.md` entry from `.gitignore`.

The guidance file was already tracked in this repo, so the ignore rule never
had any effect on it — it only risked confusing future changes to the file.

The adjacent `.claude` entry is left in place; that directory holds
per-developer local state and should stay ignored.

## Follow-on commit

Prettier defaults its ignore-path to `.gitignore`, so while `CLAUDE.md` was
listed there it was silently skipped by `format:check`. Un-ignoring it brought
it into scope and the pre-push hook failed. The second commit is the resulting
`prettier --write`, whose only change is emphasis style (`*product*` →
`_product_`).

## Verification

- `format:check` passes (it was failing before the style commit)
- pre-commit hooks ran: markdownlint `--fix`, prettier `--write`, gitleaks (no leaks)
- `git check-ignore CLAUDE.md` now reports not-ignored