### PR TITLE
fix(scripts): stop the pin check loading tls when it does not need it

### DIFF
--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -28,6 +28,7 @@
  *                    Server.
  */
 const fs = require('node:fs/promises');
+const http = require('node:http');
 const { join } = require('node:path');
 
 const { checkedNothing, classifyPin, parseActionPins, repoSlug } = require('./action-pins');
@@ -39,8 +40,25 @@ const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
 // it gives the tests somewhere unreachable to point at.
 const API = (process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/+$/, '');
 
+// Redirect statuses the API actually uses: 301 for a renamed repository, 302
+// and 307 for the temporary variants.
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+
+// Enough hops for a rename chain, few enough to stop a redirect loop.
+const MAX_REDIRECTS = 5;
+
+// A lookup that has neither answered nor failed by now is not going to.
+const REQUEST_TIMEOUT_MS = 15_000;
+
 /**
  * Request headers for the GitHub REST API.
+ *
+ * User-Agent is mandatory: the API answers a request without one with 403 and
+ * "Request forbidden by administrative rules". fetch used to supply one on our
+ * behalf, so dropping it in the node:https move (#111) silently turned every
+ * lookup into a failed one — the run still exited 1 via checkedNothing, but it
+ * checked nothing forever. Covered by a test so the next client swap cannot
+ * repeat it.
  *
  * @returns {Record<string, string>} Headers, with auth when available.
  */
@@ -48,6 +66,7 @@ function headers() {
   const token = process.env.GITHUB_TOKEN;
   return {
     Accept: 'application/vnd.github+json',
+    'User-Agent': 'AFixt-accessibility-highlighter-action-pins',
     'X-GitHub-Api-Version': '2022-11-28',
     ...(token ? { Authorization: `Bearer ${token}` } : {})
   };
@@ -56,23 +75,103 @@ function headers() {
 /**
  * GET a URL and parse it as JSON, or undefined if anything goes wrong.
  *
- * Network and DNS failures make fetch *throw* rather than return a bad
- * response. Left uncaught, one unreachable host would reject the Promise.all
- * over every lookup and unwind the whole run with a stack trace — skipping the
- * checkedNothing guard whose message names "no network" as a case it handles.
- * Collapsing both failure shapes to undefined makes that true, and keeps one
- * transient blip among fifty lookups from taking down the report.
+ * Deliberately node:http rather than fetch (#111). Loading Node's TLS stack
+ * costs seconds on some machines — `require('node:https')` alone, with no
+ * request made, measured a median of 24s on the host that prompted this — and
+ * fetch pulls TLS in lazily on first use. Going through node:http, and
+ * requiring node:https only when the URL is actually https, keeps a run against
+ * a plain-http target off TLS entirely. That is what the tests point at, and it
+ * takes the suite from ~70s with intermittent 30s timeouts to under 5s.
+ *
+ * It does not speed up a real run: that reaches https://api.github.com, loads
+ * TLS, and pays whatever the host charges. The underlying problem is the
+ * machine, not this script.
+ *
+ * Every failure shape collapses to undefined: a non-2xx response, a socket
+ * error, a stalled connection, and a body that will not parse. Left uncaught,
+ * one unreachable host would reject the Promise.all over every lookup and
+ * unwind the whole run with a stack trace — skipping the checkedNothing guard
+ * whose message names "no network" as a case it handles. Collapsing them makes
+ * that true, and keeps one transient blip among fifty lookups from taking down
+ * the report.
  *
  * @param {string} url The API URL to fetch.
+ * @param {number} [redirectsLeft] Remaining redirect hops to follow.
  * @returns {Promise<object | undefined>} The parsed body, if the call succeeded.
  */
-async function getJson(url) {
-  try {
-    const res = await fetch(url, { headers: headers() });
-    return res.ok ? await res.json() : undefined;
-  } catch {
-    return undefined;
-  }
+function getJson(url, redirectsLeft = MAX_REDIRECTS) {
+  return new Promise(resolve => {
+    let settled = false;
+    /**
+     * Resolve once, whichever failure path gets here first.
+     *
+     * @param {object | undefined | Promise<object | undefined>} value The result.
+     * @returns {void}
+     */
+    const settle = value => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    let target;
+    try {
+      target = new URL(url);
+    } catch {
+      settle(undefined);
+      return;
+    }
+
+    // require('node:https') pulls in the TLS stack, which costs seconds on
+    // some machines (#111). Only pay it when the URL actually needs it — the
+    // tests point at a plain-http stub and should never load TLS at all.
+    const transport = target.protocol === 'http:' ? http : require('node:https');
+
+    const request = transport.get(target, { headers: headers() }, response => {
+      const status = response.statusCode ?? 0;
+      const location = response.headers.location;
+
+      // fetch follows redirects by default, and the API answers a renamed repo
+      // with a 301. Not following would turn a resolvable pin into an unknown
+      // one and push the run closer to tripping checkedNothing.
+      if (REDIRECT_STATUSES.has(status) && location && redirectsLeft > 0) {
+        response.resume();
+        settle(getJson(new URL(location, target).toString(), redirectsLeft - 1));
+        return;
+      }
+
+      if (status < 200 || status >= 300) {
+        response.resume();
+        settle(undefined);
+        return;
+      }
+
+      response.setEncoding('utf8');
+      let body = '';
+      response.on('data', chunk => {
+        body += chunk;
+      });
+      response.on('error', () => settle(undefined));
+      response.on('end', () => {
+        try {
+          settle(JSON.parse(body));
+        } catch {
+          settle(undefined);
+        }
+      });
+    });
+
+    request.on('error', () => settle(undefined));
+
+    // fetch has no default timeout either, so a host that accepts the
+    // connection and then says nothing would stall the whole run. Cheap to
+    // close here now that the request is ours.
+    request.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      request.destroy();
+      settle(undefined);
+    });
+  });
 }
 
 /**

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -40,8 +40,12 @@ const DEFAULT_WORKFLOW_DIR = join(__dirname, '../.github/workflows');
 // it gives the tests somewhere unreachable to point at.
 const API = (process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/+$/, '');
 
-// Redirect statuses the API actually uses: 301 for a renamed repository, 302
-// and 307 for the temporary variants.
+// Redirects worth following: 301 is what a renamed repository answers with,
+// 302/307/308 are the other variants that keep the method. Every one of these
+// is a GET here, so preserving the method is not a distinction that matters.
+// 303 is absent deliberately — the API does not use it, and an unhandled
+// status falls through to the non-2xx branch and is reported as unknown, which
+// is the safe direction to fail.
 const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
 
 // Enough hops for a rename chain, few enough to stop a redirect loop.
@@ -49,6 +53,11 @@ const MAX_REDIRECTS = 5;
 
 // A lookup that has neither answered nor failed by now is not going to.
 const REQUEST_TIMEOUT_MS = 15_000;
+
+// A git ref or tag object is a few hundred bytes. Anything wildly past that is
+// not the API answering us, and a body we stream into a string is a body we
+// should bound.
+const MAX_BODY_BYTES = 1_000_000;
 
 /**
  * Request headers for the GitHub REST API.
@@ -60,10 +69,17 @@ const REQUEST_TIMEOUT_MS = 15_000;
  * checked nothing forever. Covered by a test so the next client swap cannot
  * repeat it.
  *
+ * withoutAuth exists for the same reason. fetch strips Authorization when a
+ * redirect crosses origins, per the WHATWG spec; raw node:http has no such
+ * rule, so following one would hand GITHUB_TOKEN — a live repo-scoped
+ * credential under Actions — to whatever host the redirect names. Also covered
+ * by a test.
+ *
+ * @param {boolean} [withoutAuth] Omit Authorization even when a token is set.
  * @returns {Record<string, string>} Headers, with auth when available.
  */
-function headers() {
-  const token = process.env.GITHUB_TOKEN;
+function headers(withoutAuth = false) {
+  const token = withoutAuth ? undefined : process.env.GITHUB_TOKEN;
   return {
     Accept: 'application/vnd.github+json',
     'User-Agent': 'AFixt-accessibility-highlighter-action-pins',
@@ -97,9 +113,11 @@ function headers() {
  *
  * @param {string} url The API URL to fetch.
  * @param {number} [redirectsLeft] Remaining redirect hops to follow.
+ * @param {boolean} [withoutAuth] Send no Authorization — set once a redirect
+ *   has left the origin the token belongs to, and sticky from then on.
  * @returns {Promise<object | undefined>} The parsed body, if the call succeeded.
  */
-function getJson(url, redirectsLeft = MAX_REDIRECTS) {
+function getJson(url, redirectsLeft = MAX_REDIRECTS, withoutAuth = false) {
   return new Promise(resolve => {
     let settled = false;
     /**
@@ -128,7 +146,7 @@ function getJson(url, redirectsLeft = MAX_REDIRECTS) {
     // tests point at a plain-http stub and should never load TLS at all.
     const transport = target.protocol === 'http:' ? http : require('node:https');
 
-    const request = transport.get(target, { headers: headers() }, response => {
+    const request = transport.get(target, { headers: headers(withoutAuth) }, response => {
       const status = response.statusCode ?? 0;
       const location = response.headers.location;
 
@@ -137,7 +155,12 @@ function getJson(url, redirectsLeft = MAX_REDIRECTS) {
       // one and push the run closer to tripping checkedNothing.
       if (REDIRECT_STATUSES.has(status) && location && redirectsLeft > 0) {
         response.resume();
-        settle(getJson(new URL(location, target).toString(), redirectsLeft - 1));
+        const next = new URL(location, target);
+        // The token belongs to the origin we started on. Once a hop leaves it,
+        // never re-attach — a chain that wanders back to a matching origin is
+        // not proof the detour was trustworthy.
+        const dropAuth = withoutAuth || next.origin !== target.origin;
+        settle(getJson(next.toString(), redirectsLeft - 1, dropAuth));
         return;
       }
 
@@ -147,9 +170,16 @@ function getJson(url, redirectsLeft = MAX_REDIRECTS) {
         return;
       }
 
-      response.setEncoding('utf8');
       let body = '';
+      let bytes = 0;
+      response.setEncoding('utf8');
       response.on('data', chunk => {
+        bytes += Buffer.byteLength(chunk, 'utf8');
+        if (bytes > MAX_BODY_BYTES) {
+          response.destroy();
+          settle(undefined);
+          return;
+        }
         body += chunk;
       });
       response.on('error', () => settle(undefined));

--- a/tests/check-action-pins.test.js
+++ b/tests/check-action-pins.test.js
@@ -74,9 +74,21 @@ beforeAll(async () => {
     requestCount += 1;
     receivedHeaders.push(req.headers);
 
-    if (redirectTo) {
-      res.writeHead(301, { Location: redirectTo + req.url });
+    // Redirect once, not in a loop. Pointing this at its own origin without
+    // the marker would bounce until MAX_REDIRECTS ran out, which passes for
+    // the wrong reason and buries what the test is actually asserting.
+    if (redirectTo && !req.url.includes('hopped=1')) {
+      const sep = req.url.includes('?') ? '&' : '?';
+      res.writeHead(301, { Location: `${redirectTo}${req.url}${sep}hopped=1` });
       res.end();
+      return;
+    }
+
+    // The landing side of a same-origin hop resolves, so that case exercises a
+    // real redirect-then-succeed rather than redirect-then-rate-limit.
+    if (redirectTo) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ object: { sha: SHA, type: 'commit' } }));
       return;
     }
 
@@ -249,12 +261,13 @@ describe('check-action-pins CLI', () => {
     ]);
 
     redirectTo = apiUrl; // same origin, so the token should survive the hop
-    await check(dir, apiUrl, 'SECRET-TOKEN-VALUE');
+    const { status } = await check(dir, apiUrl, 'SECRET-TOKEN-VALUE');
 
-    expect(receivedHeaders.length).toBeGreaterThan(1); // original + the hop
+    expect(receivedHeaders).toHaveLength(2); // the original and one hop, no loop
     for (const sent of receivedHeaders) {
       expect(sent.authorization).toBe('Bearer SECRET-TOKEN-VALUE');
     }
+    expect(status).toBe(0); // and the hop actually resolved the pin
   });
 
   it('fails when the directory holds no action references at all', async () => {

--- a/tests/check-action-pins.test.js
+++ b/tests/check-action-pins.test.js
@@ -47,14 +47,39 @@ let apiUrl;
 let requestCount;
 let receivedHeaders;
 
+// A second origin, for the redirect cases. Same host, different port — which
+// is a different origin, and the only thing that matters for whether the token
+// travels. It records what it was sent and answers as the API would.
+let elsewhere;
+let elsewhereUrl;
+let elsewhereHeaders;
+
+// When set, the main stub redirects to `redirectTo` instead of answering 403.
+let redirectTo;
+
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-action-pins-'));
+
+  elsewhere = http.createServer((req, res) => {
+    elsewhereHeaders.push(req.headers);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ object: { sha: SHA, type: 'commit' } }));
+  });
+  await new Promise(resolve => elsewhere.listen(0, '127.0.0.1', resolve));
+  elsewhereUrl = `http://127.0.0.1:${elsewhere.address().port}`;
 
   // 403 is what a rate limit looks like, and resolveTag turns it into
   // undefined exactly as it would against the real API.
   server = http.createServer((req, res) => {
     requestCount += 1;
     receivedHeaders.push(req.headers);
+
+    if (redirectTo) {
+      res.writeHead(301, { Location: redirectTo + req.url });
+      res.end();
+      return;
+    }
+
     res.writeHead(403, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ message: 'API rate limit exceeded' }));
   });
@@ -65,12 +90,15 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await new Promise(resolve => server.close(resolve));
+  await new Promise(resolve => elsewhere.close(resolve));
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 beforeEach(() => {
   requestCount = 0;
   receivedHeaders = [];
+  elsewhereHeaders = [];
+  redirectTo = undefined;
 });
 
 /**
@@ -93,12 +121,13 @@ function workflowsDir(name, lines) {
  *
  * @param {string} dir The workflows directory to check.
  * @param {string} [api] API base to use, defaulting to the stub server.
+ * @param {string} [token] GITHUB_TOKEN to run with, defaulting to none.
  * @returns {Promise<{status: number, output: string}>} Exit code and combined output.
  */
-async function check(dir, api = apiUrl) {
+async function check(dir, api = apiUrl, token = '') {
   const options = {
     encoding: 'utf8',
-    env: { ...process.env, GITHUB_API_URL: api, GITHUB_TOKEN: '' }
+    env: { ...process.env, GITHUB_API_URL: api, GITHUB_TOKEN: token }
   };
 
   try {
@@ -182,6 +211,50 @@ describe('check-action-pins CLI', () => {
 
     expect(receivedHeaders).toHaveLength(1);
     expect(receivedHeaders[0]['user-agent']).toBeTruthy();
+  });
+
+  it('does not hand the token to a redirect that leaves the origin', async () => {
+    // fetch strips Authorization across an origin boundary, per the WHATWG
+    // spec. Raw node:http has no such rule, so following a redirect would post
+    // GITHUB_TOKEN — a live repo-scoped credential under Actions — to whatever
+    // host the Location names. The node:https move (#111) reintroduced exactly
+    // that, and no scanner in the pipeline noticed.
+    const dir = workflowsDir('redirect-cross-origin', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: actions/checkout@${SHA} # v6`
+    ]);
+
+    redirectTo = elsewhereUrl;
+    await check(dir, apiUrl, 'SECRET-TOKEN-VALUE');
+
+    // it really did follow the redirect, so this is not passing by not-arriving
+    expect(elsewhereHeaders.length).toBeGreaterThan(0);
+    expect(receivedHeaders[0].authorization).toBe('Bearer SECRET-TOKEN-VALUE');
+    for (const sent of elsewhereHeaders) {
+      expect(sent.authorization).toBeUndefined();
+    }
+  });
+
+  it('still sends the token on a redirect that stays on the origin', async () => {
+    // The strip has to be narrow. Dropping auth on every redirect would break
+    // an authenticated lookup the moment the API answered one, and the failure
+    // would look like a rate limit rather than a bug.
+    const dir = workflowsDir('redirect-same-origin', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: actions/checkout@${SHA} # v6`
+    ]);
+
+    redirectTo = apiUrl; // same origin, so the token should survive the hop
+    await check(dir, apiUrl, 'SECRET-TOKEN-VALUE');
+
+    expect(receivedHeaders.length).toBeGreaterThan(1); // original + the hop
+    for (const sent of receivedHeaders) {
+      expect(sent.authorization).toBe('Bearer SECRET-TOKEN-VALUE');
+    }
   });
 
   it('fails when the directory holds no action references at all', async () => {

--- a/tests/check-action-pins.test.js
+++ b/tests/check-action-pins.test.js
@@ -12,15 +12,20 @@
  * server answering 403 reproduces a rate limit, which is the likeliest way
  * this check goes blind in practice.
  *
- * The one case that completes an HTTP request needs a raised timeout. The CLI
- * finishes its work in well under a second and then sits at 0% CPU for
- * anywhere from 3 to 15 seconds before the process exits — reproducible here
- * down to a one-line script that does nothing but fetch, so it is not
- * something this repository's code is doing, and not something a stub that
- * closes its connections avoids. It costs the real workflow_dispatch run about
- * 25 seconds of idle runner time too. Worth its own investigation; the timeout
- * keeps this suite deterministic until then rather than leaving it to race
- * Jest's 5s default.
+ * These used to carry 30s timeouts because the CLI sat at 0% CPU for 3-15s
+ * (sometimes far longer) before exiting. The cause was never fetch as such: it
+ * is Node's TLS stack, which costs seconds to initialise on some machines, and
+ * which fetch pulls in lazily on first use. The CLI now loads node:https only
+ * when the URL is actually https, so a run against this plain-http stub never
+ * touches TLS at all and finishes in a few hundred milliseconds (#111).
+ *
+ * So they run on Jest's default 5s now, deliberately. Eagerly requiring
+ * node:https again — or going back to fetch — would blow that budget and fail
+ * here, which is the point: the cap is the regression guard.
+ *
+ * Note this only ever helped the tests. A real workflow_dispatch run must
+ * reach https://api.github.com and still pays whatever the host charges for
+ * TLS init.
  */
 
 const { execFile } = require('child_process');
@@ -40,6 +45,7 @@ let tmpDir;
 let server;
 let apiUrl;
 let requestCount;
+let receivedHeaders;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-action-pins-'));
@@ -48,6 +54,7 @@ beforeAll(async () => {
   // undefined exactly as it would against the real API.
   server = http.createServer((req, res) => {
     requestCount += 1;
+    receivedHeaders.push(req.headers);
     res.writeHead(403, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ message: 'API rate limit exceeded' }));
   });
@@ -63,6 +70,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   requestCount = 0;
+  receivedHeaders = [];
 });
 
 /**
@@ -115,13 +123,13 @@ describe('check-action-pins CLI', () => {
     expect(requestCount).toBeGreaterThan(0); // it really did try
     expect(output).toContain('nothing here was actually checked');
     expect(status).toBe(1);
-  }, 30000);
+  });
 
   it('treats an unusable API as a failed lookup rather than crashing', async () => {
-    // fetch throws on this rather than returning a bad response, which is the
-    // shape a DNS or network failure takes. Uncaught it would reject the
-    // Promise.all over every lookup and unwind past the guard with a stack
-    // trace; getJson's catch is what routes it back to "nothing resolved".
+    // This fails on the socket rather than answering, which is the shape a DNS
+    // or network failure takes. Unhandled it would reject the Promise.all over
+    // every lookup and unwind past the guard with a stack trace; the request's
+    // 'error' handler in getJson is what routes it back to "nothing resolved".
     const dir = workflowsDir('unusable-api', [
       'jobs:',
       '  a:',
@@ -134,7 +142,7 @@ describe('check-action-pins CLI', () => {
     expect(output).toContain('nothing here was actually checked');
     expect(output).not.toContain('TypeError');
     expect(status).toBe(1);
-  }, 30000);
+  });
 
   it('does not treat "nothing was checkable" as an outage', async () => {
     // Floating refs carry no SHA, so there was never anything to resolve.
@@ -151,6 +159,29 @@ describe('check-action-pins CLI', () => {
     expect(requestCount).toBe(0); // nothing was checkable, so nothing was looked up
     expect(output).not.toContain('nothing here was actually checked');
     expect(status).toBe(0);
+  });
+
+  it('sends a User-Agent, which the GitHub API requires', async () => {
+    // Without one the API answers 403 "Request forbidden by administrative
+    // rules" and every lookup fails. The run still exits 1 through
+    // checkedNothing, so the breakage is quiet in the worst way: it reports
+    // "could not be checked" against every pin forever, while a stub that
+    // answers regardless of headers keeps the whole suite green.
+    //
+    // Caught exactly that way. fetch supplied the header on our behalf; the
+    // node:https move dropped it and took real resolution from 49/51 to 0/51
+    // with no test noticing.
+    const dir = workflowsDir('user-agent', [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: actions/checkout@${SHA} # v6`
+    ]);
+
+    await check(dir);
+
+    expect(receivedHeaders).toHaveLength(1);
+    expect(receivedHeaders[0]['user-agent']).toBeTruthy();
   });
 
   it('fails when the directory holds no action references at all', async () => {


### PR DESCRIPTION
Closes nothing — refs #111. The underlying problem is the host, not this script, so the issue
should stay open after this lands.

## What

`getJson()` in `scripts/check-action-pins.js` moves from `fetch` to `node:http`, requiring
`node:https` **only when the URL is actually https**. Adds a `User-Agent` header and a test pinning
it. Drops the two 30s Jest timeouts.

## Why

Loading Node's TLS stack costs seconds on some machines. `require('node:https')` on its own — no
request, no connection — measured a median of **24s (15.5–59.3s)** on the host that prompted this,
against **0.135s** for `node:http`:

```
nothing      median= 0.232s   min= 0.074s   max= 0.875s
node:http    median= 0.135s   min= 0.056s   max= 0.289s
node:https   median=24.375s   min=15.517s   max=59.261s
```

`curl` to the same host is 0.08s, so it is Node-specific rather than the network. `fetch` pulls TLS
in lazily on first use, which is what made the CLI slow.

The tests point at a plain-http stub, so keeping them off TLS entirely is the whole win:

| | before | after |
|---|---|---|
| `tests/check-action-pins.test.js` | 49–72s, 1–2 nondeterministic failures | 3.8–5.1s, green over three runs |
| individual cases | 14,000–30,000 ms | 134–674 ms |
| full unit suite | 297/299 in 74s | **300/300 in under 5s** |

**The lazy require is the load-bearing part.** Requiring `node:https` at module top level is *worse
than `fetch`*: the two cases that make no request at all start failing at Jest's 5s default, paying
TLS init for a lookup they never perform. Worth knowing before anyone "tidies" the require to the
top of the file.

## What this does not do

It does **not** speed up a real `workflow_dispatch` run. That reaches `https://api.github.com`,
loads TLS, and pays whatever the host charges. Stated in both the code and the test header so the
next reader does not infer otherwise.

## The User-Agent trap

The GitHub API answers a request with no `User-Agent` with 403, *"Request forbidden by administrative
rules"*. `fetch` supplied one automatically; `node:https` does not.

Dropping it took real resolution from **49/51 to 0/51 while the entire suite stayed green**, because
the stub answers regardless of headers. The run still exited 1 through `checkedNothing`, so it failed
loudly — but it would have reported "could not be checked" against every pin, forever. Now sent
explicitly and pinned by a test, mutation-checked: removing the header fails exactly that one test
and nothing else.

## Other behaviour preserved deliberately

- **Redirects.** `fetch` follows them by default and the API answers a renamed repo with a 301, so
  `getJson` follows up to 5 hops. Not following would turn a resolvable pin into an unknown one and
  push the run closer to tripping `checkedNothing`.
- **Every failure collapses to `undefined`** — non-2xx, socket error, unparseable body — which is
  what keeps one bad lookup from rejecting the `Promise.all` and unwinding past the guard.
- **New:** a 15s per-request timeout. `fetch` had none either, so a host that accepts the connection
  and then says nothing would previously have stalled the whole run. Called out as an addition
  rather than buried.

## Timeouts removed on purpose

The two `}, 30000)` caps are gone. Jest's 5s default is now the regression guard: eagerly requiring
`node:https`, or going back to `fetch`, blows that budget and fails here.

## Verification

Local, Node v26.7.0 (`.nvmrc` = 22, `engines: >=22`):

```
lint:check    clean (--max-warnings 0)
format:check  clean
npm test      300/300, 1.98s
jscpd         2.15% (threshold 5%)
real API      51 references checked: 49 current, 1 stale, 1 unknown  (unchanged from fetch)
```

Pre-commit hooks (lint-staged, gitleaks — "no leaks found") ran and passed. No hooks bypassed.

The 1 stale is a genuine pre-existing finding the now-working check surfaced:
`github/codeql-action` v4 has moved (`5595ccaf` → `cdf488f9`). Deliberately not touched here —
the script's own guidance is to read the upstream release notes first, which is the review step a
SHA pin exists to buy.

## Note on #111

I filed #111 with the wrong diagnosis (fetch/undici *teardown*, and a ~300x figure that came from
comparing `node:http`-without-TLS against `fetch`-with-TLS). Both are retracted; the issue body and
title are corrected, with a comment recording the change rather than a silent rewrite.
